### PR TITLE
Add Microsoft shared mailbox support

### DIFF
--- a/app/account.go
+++ b/app/account.go
@@ -57,6 +57,102 @@ func (a *App) AddAccount(config account.AccountConfig) (*account.Account, error)
 	return acc, nil
 }
 
+// AddMicrosoftSharedMailbox creates a linked Microsoft shared mailbox account
+// that reuses OAuth tokens from an existing primary Microsoft account.
+func (a *App) AddMicrosoftSharedMailbox(primaryAccountID, sharedEmail, displayName string) (*account.Account, error) {
+	log := logging.WithComponent("app")
+
+	primary, err := a.accountStore.Get(primaryAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get primary account: %w", err)
+	}
+	if primary == nil {
+		return nil, fmt.Errorf("primary account not found: %s", primaryAccountID)
+	}
+	if primary.Provider != "microsoft" {
+		return nil, fmt.Errorf("shared mailboxes are currently supported for Microsoft accounts only")
+	}
+	if primary.Kind != account.AccountKindPrimary {
+		return nil, fmt.Errorf("shared mailboxes can only be added from a primary Microsoft account")
+	}
+	if primary.AuthType != account.AuthOAuth2 {
+		return nil, fmt.Errorf("Microsoft shared mailboxes require OAuth")
+	}
+	if sharedEmail == "" {
+		return nil, fmt.Errorf("shared mailbox email is required")
+	}
+	if displayName == "" {
+		displayName = sharedEmail
+	}
+
+	tokens, err := a.getValidOAuthToken(primary.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Microsoft OAuth token: %w", err)
+	}
+
+	clientConfig := imap.DefaultConfig()
+	clientConfig.Host = primary.IMAPHost
+	clientConfig.Port = primary.IMAPPort
+	clientConfig.Security = imap.SecurityType(primary.IMAPSecurity)
+	clientConfig.Username = sharedEmail
+	clientConfig.AuthType = imap.AuthTypeOAuth2
+	clientConfig.AccessToken = tokens.AccessToken
+
+	client := imap.NewClient(clientConfig)
+	if err := client.Connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to Microsoft IMAP: %w", err)
+	}
+	defer client.Close()
+
+	if err := client.Login(); err != nil {
+		return nil, fmt.Errorf("failed to authenticate shared mailbox %s: %w", sharedEmail, err)
+	}
+
+	if _, err := client.ListMailboxes(); err != nil {
+		return nil, fmt.Errorf("failed to access shared mailbox %s: %w", sharedEmail, err)
+	}
+
+	config := account.AccountConfig{
+		Name:                     sharedEmail,
+		DisplayName:              displayName,
+		Email:                    sharedEmail,
+		Kind:                     account.AccountKindShared,
+		Provider:                 "microsoft",
+		OAuthSourceAccountID:     primary.ID,
+		IMAPHost:                 primary.IMAPHost,
+		IMAPPort:                 primary.IMAPPort,
+		IMAPSecurity:             primary.IMAPSecurity,
+		SMTPHost:                 primary.SMTPHost,
+		SMTPPort:                 primary.SMTPPort,
+		SMTPSecurity:             primary.SMTPSecurity,
+		AuthType:                 account.AuthOAuth2,
+		Username:                 sharedEmail,
+		Color:                    primary.Color,
+		SyncPeriodDays:           primary.SyncPeriodDays,
+		SyncInterval:             primary.SyncInterval,
+		ReadReceiptRequestPolicy: primary.ReadReceiptRequestPolicy,
+	}
+
+	acc, err := a.accountStore.Create(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	a.updateDBConnectionPool()
+
+	if a.idleManager != nil && acc.Enabled {
+		a.idleManager.StartAccount(acc.ID, acc.Name)
+	}
+
+	log.Info().
+		Str("account_id", acc.ID).
+		Str("shared_email", sharedEmail).
+		Str("primary_account_id", primary.ID).
+		Msg("Microsoft shared mailbox created")
+
+	return acc, nil
+}
+
 // UpdateAccount updates an existing account
 func (a *App) UpdateAccount(id string, config account.AccountConfig) (*account.Account, error) {
 	log := logging.WithComponent("app")
@@ -256,9 +352,9 @@ func (a *App) SetDefaultIdentity(accountID, identityID string) error {
 
 // ConnectionTestResult holds the result of a connection test
 type ConnectionTestResult struct {
-	Success             bool                      `json:"success"`
-	Error               string                    `json:"error,omitempty"`
-	CertificateRequired bool                      `json:"certificateRequired"`
+	Success             bool                         `json:"success"`
+	Error               string                       `json:"error,omitempty"`
+	CertificateRequired bool                         `json:"certificateRequired"`
 	Certificate         *certificate.CertificateInfo `json:"certificate,omitempty"`
 }
 

--- a/app/compose.go
+++ b/app/compose.go
@@ -352,8 +352,13 @@ func (ops *composeOps) sendMessage(ctx context.Context, accountID string, msg sm
 	smtpConfig.Host = acc.SMTPHost
 	smtpConfig.Port = acc.SMTPPort
 	smtpConfig.Security = smtp.SecurityType(acc.SMTPSecurity)
-	smtpConfig.Username = acc.Username
 	smtpConfig.TLSConfig = certificate.BuildTLSConfig(acc.SMTPHost, ops.certStore)
+
+	smtpUsername, err := resolveSMTPAuthUsername(ops.accountStore, acc)
+	if err != nil {
+		return nil, err
+	}
+	smtpConfig.Username = smtpUsername
 
 	// Handle authentication based on auth type
 	switch acc.AuthType {

--- a/app/compose.go
+++ b/app/compose.go
@@ -58,7 +58,19 @@ type composeOps struct {
 func (ops *composeOps) getValidOAuthToken(ctx context.Context, accountID string) (*credentials.OAuthTokens, error) {
 	log := logging.WithComponent("composeOps")
 
-	tokens, err := ops.credStore.GetOAuthTokens(accountID)
+	tokenAccountID := accountID
+	acc, err := ops.accountStore.Get(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account: %w", err)
+	}
+	if acc == nil {
+		return nil, fmt.Errorf("account not found: %s", accountID)
+	}
+	if acc.OAuthSourceAccountID != "" {
+		tokenAccountID = acc.OAuthSourceAccountID
+	}
+
+	tokens, err := ops.credStore.GetOAuthTokens(tokenAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OAuth tokens: %w", err)
 	}
@@ -69,7 +81,7 @@ func (ops *composeOps) getValidOAuthToken(ctx context.Context, accountID string)
 	}
 
 	log.Debug().
-		Str("account_id", accountID).
+		Str("account_id", tokenAccountID).
 		Time("expires_at", tokens.ExpiresAt).
 		Msg("OAuth token expiring soon, refreshing")
 
@@ -77,12 +89,12 @@ func (ops *composeOps) getValidOAuthToken(ctx context.Context, accountID string)
 	newTokenResp, err := ops.oauth2Manager.RefreshToken(tokens.Provider, tokens.RefreshToken)
 	if err != nil {
 		log.Error().Err(err).
-			Str("account_id", accountID).
+			Str("account_id", tokenAccountID).
 			Msg("OAuth token refresh failed")
 
 		// Emit event for frontend to prompt re-authorization
 		wailsRuntime.EventsEmit(ctx, "oauth:reauth-required", map[string]interface{}{
-			"accountId": accountID,
+			"accountId": tokenAccountID,
 			"provider":  tokens.Provider,
 			"error":     err.Error(),
 		})
@@ -100,13 +112,13 @@ func (ops *composeOps) getValidOAuthToken(ctx context.Context, accountID string)
 		tokens.RefreshToken = newTokenResp.RefreshToken
 	}
 
-	if err := ops.credStore.SetOAuthTokens(accountID, tokens); err != nil {
+	if err := ops.credStore.SetOAuthTokens(tokenAccountID, tokens); err != nil {
 		log.Warn().Err(err).Msg("Failed to save refreshed OAuth tokens")
 		// Continue anyway - we have valid tokens in memory
 	}
 
 	log.Info().
-		Str("account_id", accountID).
+		Str("account_id", tokenAccountID).
 		Time("new_expires_at", expiresAt).
 		Msg("OAuth token refreshed successfully")
 
@@ -899,7 +911,7 @@ func quoteText(s string) string {
 func providerAutoSavesSentMail(host string) bool {
 	host = strings.ToLower(host)
 	autoSaveProviders := []string{
-		"imap.gmail.com",       // Gmail
+		"imap.gmail.com",        // Gmail
 		"outlook.office365.com", // Microsoft 365
 		"imap-mail.outlook.com", // Outlook.com
 	}
@@ -1012,4 +1024,3 @@ func detectContentType(filename string) string {
 		return "application/octet-stream"
 	}
 }
-

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -129,6 +129,8 @@ func (a *App) CompleteOAuthAccountSetup(provider, email, accountName, displayNam
 			DisplayName:    displayName,
 			Color:          color,
 			Email:          email,
+			Kind:           account.AccountKindPrimary,
+			Provider:       provider,
 			Username:       email,
 			AuthType:       account.AuthOAuth2,
 			IMAPHost:       "imap.gmail.com",
@@ -146,6 +148,8 @@ func (a *App) CompleteOAuthAccountSetup(provider, email, accountName, displayNam
 			DisplayName:    displayName,
 			Color:          color,
 			Email:          email,
+			Kind:           account.AccountKindPrimary,
+			Provider:       provider,
 			Username:       email,
 			AuthType:       account.AuthOAuth2,
 			IMAPHost:       "outlook.office365.com",
@@ -258,8 +262,21 @@ func (a *App) SavePendingOAuthTokens(accountID string) error {
 		return fmt.Errorf("no pending OAuth tokens to save")
 	}
 
+	acc, err := a.accountStore.Get(accountID)
+	if err != nil {
+		return fmt.Errorf("failed to get account: %w", err)
+	}
+	if acc == nil {
+		return fmt.Errorf("account not found: %s", accountID)
+	}
+
+	providerAccountID := accountID
+	if acc.OAuthSourceAccountID != "" {
+		providerAccountID = acc.OAuthSourceAccountID
+	}
+
 	// Get the provider from the account
-	provider, err := a.credStore.GetOAuthProvider(accountID)
+	provider, err := a.credStore.GetOAuthProvider(providerAccountID)
 	if err != nil || provider == "" {
 		return fmt.Errorf("could not determine OAuth provider for account")
 	}
@@ -281,12 +298,12 @@ func (a *App) SavePendingOAuthTokens(accountID string) error {
 		Scopes:       providerConfig.Scopes,
 	}
 
-	if err := a.credStore.SetOAuthTokens(accountID, tokens); err != nil {
+	if err := a.credStore.SetOAuthTokens(providerAccountID, tokens); err != nil {
 		return fmt.Errorf("failed to store OAuth tokens: %w", err)
 	}
 
 	log.Info().
-		Str("accountID", accountID).
+		Str("accountID", providerAccountID).
 		Str("provider", provider).
 		Time("expiresAt", expiresAt).
 		Msg("Pending OAuth tokens saved to account")
@@ -331,10 +348,15 @@ func (a *App) GetOAuthStatus(accountID string) (*OAuthStatus, error) {
 	}
 
 	// Get OAuth token info
-	tokens, err := a.credStore.GetOAuthTokens(accountID)
+	tokenAccountID := accountID
+	if acc.OAuthSourceAccountID != "" {
+		tokenAccountID = acc.OAuthSourceAccountID
+	}
+	tokens, err := a.credStore.GetOAuthTokens(tokenAccountID)
 	if err != nil {
 		// Tokens not found - needs re-auth
 		status.NeedsReauth = true
+		status.Provider = acc.Provider
 		return status, nil
 	}
 
@@ -380,14 +402,19 @@ func (a *App) ReauthorizeAccount(accountID string) error {
 		return fmt.Errorf("account is not an OAuth account")
 	}
 
+	providerAccountID := accountID
+	if acc.OAuthSourceAccountID != "" {
+		providerAccountID = acc.OAuthSourceAccountID
+	}
+
 	// Get the provider from stored tokens
-	provider, err := a.credStore.GetOAuthProvider(accountID)
+	provider, err := a.credStore.GetOAuthProvider(providerAccountID)
 	if err != nil || provider == "" {
 		return fmt.Errorf("could not determine OAuth provider for account")
 	}
 
 	log.Info().
-		Str("accountID", accountID).
+		Str("accountID", providerAccountID).
 		Str("provider", provider).
 		Msg("Starting re-authorization for account")
 

--- a/app/settings.go
+++ b/app/settings.go
@@ -305,10 +305,15 @@ func (a *App) SendReadReceipt(accountID, messageID string) error {
 	}
 
 	// Create SMTP config
+	smtpUsername, err := resolveSMTPAuthUsername(a.accountStore, acc)
+	if err != nil {
+		return err
+	}
+
 	smtpConfig := smtp.ClientConfig{
 		Host:      acc.SMTPHost,
 		Port:      acc.SMTPPort,
-		Username:  acc.Username,
+		Username:  smtpUsername,
 		Security:  smtp.SecurityType(acc.SMTPSecurity),
 		TLSConfig: certificate.BuildTLSConfig(acc.SMTPHost, a.certStore),
 	}

--- a/app/smtp_auth.go
+++ b/app/smtp_auth.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/hkdb/aerion/internal/account"
+)
+
+// resolveSMTPAuthUsername returns the SMTP auth username for an account.
+// For Microsoft shared mailboxes, authenticate as the source user while
+// preserving the shared mailbox address in the message headers/envelope.
+func resolveSMTPAuthUsername(store *account.Store, acc *account.Account) (string, error) {
+	if acc == nil {
+		return "", fmt.Errorf("account is nil")
+	}
+
+	if acc.Provider != "microsoft" || acc.Kind != account.AccountKindShared || acc.OAuthSourceAccountID == "" {
+		return acc.Username, nil
+	}
+
+	source, err := store.Get(acc.OAuthSourceAccountID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get source account for SMTP auth: %w", err)
+	}
+	if source == nil {
+		return "", fmt.Errorf("source account not found for SMTP auth: %s", acc.OAuthSourceAccountID)
+	}
+	if source.Username == "" {
+		return "", fmt.Errorf("source account has no SMTP auth username: %s", source.ID)
+	}
+
+	return source.Username, nil
+}

--- a/frontend/src/lib/components/settings/AccountDialog.svelte
+++ b/frontend/src/lib/components/settings/AccountDialog.svelte
@@ -152,6 +152,9 @@
         displayName,
         color,
         email,
+        kind: editAccount.kind,
+        provider: editAccount.provider,
+        oauthSourceAccountId: editAccount.oauthSourceAccountId,
         username: username || email,
         password: password, // Empty = keep current
         imapHost,
@@ -335,7 +338,7 @@
           </Tabs.Content>
 
           <Tabs.Content value="identity" class="mt-0">
-            <AccountIdentityTab accountId={editAccount.id} />
+            <AccountIdentityTab accountId={editAccount.id} accountData={editAccount} />
           </Tabs.Content>
 
           <Tabs.Content value="security" class="mt-0">

--- a/frontend/src/lib/components/settings/account/AccountIdentityTab.svelte
+++ b/frontend/src/lib/components/settings/account/AccountIdentityTab.svelte
@@ -2,7 +2,11 @@
   import { onMount } from 'svelte'
   import Icon from '@iconify/svelte'
   import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Label } from '$lib/components/ui/label'
+  import * as Dialog from '$lib/components/ui/dialog'
   import IdentityEditor from './IdentityEditor.svelte'
+  import { accountStore } from '$lib/stores/accounts.svelte'
   import { addToast } from '$lib/stores/toast'
   import { _ } from '$lib/i18n'
   // @ts-ignore - wailsjs path
@@ -11,18 +15,22 @@
   import { GetIdentities, CreateIdentity, UpdateIdentity, DeleteIdentity, SetDefaultIdentity } from '../../../../../wailsjs/go/app/App'
 
   interface Props {
-    /** The account being edited */
     accountId: string
+    accountData?: account.Account | null
   }
 
-  let { accountId }: Props = $props()
+  let { accountId, accountData = null }: Props = $props()
 
-  // State
   let identities = $state<account.Identity[]>([])
   let loading = $state(true)
   let showEditor = $state(false)
   let editingIdentity = $state<account.Identity | null>(null)
   let deletingId = $state<string | null>(null)
+  let showSharedMailboxDialog = $state(false)
+  let sharedMailboxEmail = $state('')
+  let sharedMailboxDisplayName = $state('')
+  let addingSharedMailbox = $state(false)
+  let sharedMailboxError = $state('')
 
   onMount(async () => {
     await loadIdentities()
@@ -55,14 +63,12 @@
 
   async function handleSaveIdentity(config: account.IdentityConfig) {
     if (editingIdentity) {
-      // Update existing
       await UpdateIdentity(editingIdentity.id, config)
       addToast({
         type: 'success',
         message: $_('identity.emailUpdated'),
       })
     } else {
-      // Create new
       await CreateIdentity(accountId, config)
       addToast({
         type: 'success',
@@ -119,21 +125,62 @@
     }
   }
 
-  // Get a preview of the signature (first line, truncated)
   function getSignaturePreview(identity: account.Identity): string {
     if (!identity.signatureEnabled) return $_('identity.noSignature')
     if (!identity.signatureHtml) return $_('identity.noSignature')
-    
-    // Strip HTML and get first line
+
     const temp = document.createElement('div')
     temp.innerHTML = identity.signatureHtml
     const text = temp.textContent || ''
     const firstLine = text.split('\n')[0].trim()
-    
+
     if (firstLine.length > 50) {
       return firstLine.substring(0, 50) + '...'
     }
     return firstLine || $_('identity.emptySignature')
+  }
+
+  function canAddSharedMailbox(): boolean {
+    return accountData?.provider === 'microsoft' &&
+      accountData?.kind === 'primary' &&
+      accountData?.authType === 'oauth2'
+  }
+
+  function openSharedMailboxDialog() {
+    sharedMailboxEmail = ''
+    sharedMailboxDisplayName = ''
+    sharedMailboxError = ''
+    showSharedMailboxDialog = true
+  }
+
+  async function handleAddSharedMailbox() {
+    sharedMailboxError = ''
+    const email = sharedMailboxEmail.trim()
+    const displayName = sharedMailboxDisplayName.trim() || email
+
+    if (!email) {
+      sharedMailboxError = $_('identity.sharedMailboxEmailRequired')
+      return
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      sharedMailboxError = $_('identity.sharedMailboxEmailInvalid')
+      return
+    }
+
+    addingSharedMailbox = true
+    try {
+      await accountStore.addMicrosoftSharedMailbox(accountId, email, displayName)
+      addToast({
+        type: 'success',
+        message: $_('identity.sharedMailboxAdded', { values: { email } }),
+      })
+      showSharedMailboxDialog = false
+    } catch (err) {
+      console.error('Failed to add shared mailbox:', err)
+      sharedMailboxError = err instanceof Error ? err.message : String(err)
+    } finally {
+      addingSharedMailbox = false
+    }
   }
 </script>
 
@@ -148,10 +195,18 @@
         {$_('identity.emailAddressesHelp')}
       </p>
     </div>
-    <Button size="sm" onclick={handleAddIdentity}>
-      <Icon icon="mdi:plus" class="w-4 h-4 mr-1" />
-      {$_('identity.addEmailAddress')}
-    </Button>
+    <div class="flex items-center gap-2">
+      {#if canAddSharedMailbox()}
+        <Button size="sm" variant="outline" onclick={openSharedMailboxDialog}>
+          <Icon icon="mdi:mailbox-outline" class="w-4 h-4 mr-1" />
+          {$_('identity.addSharedMailbox')}
+        </Button>
+      {/if}
+      <Button size="sm" onclick={handleAddIdentity}>
+        <Icon icon="mdi:plus" class="w-4 h-4 mr-1" />
+        {$_('identity.addEmailAddress')}
+      </Button>
+    </div>
   </div>
 
   {#if loading}
@@ -167,13 +222,12 @@
     <div class="space-y-2">
       {#each identities as identity (identity.id)}
         <div class="flex items-center gap-3 p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors group">
-          <!-- Default radio button -->
           <button
             type="button"
             onclick={() => handleSetDefault(identity)}
             class="flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors
-              {identity.isDefault 
-                ? 'border-primary bg-primary' 
+              {identity.isDefault
+                ? 'border-primary bg-primary'
                 : 'border-muted-foreground hover:border-primary'}"
             title={identity.isDefault ? $_('identity.defaultAddress') : $_('identity.setAsDefaultAddress')}
           >
@@ -182,7 +236,6 @@
             {/if}
           </button>
 
-          <!-- Identity info -->
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2">
               <span class="font-medium text-sm truncate">{identity.email}</span>
@@ -199,7 +252,6 @@
             </div>
           </div>
 
-          <!-- Actions -->
           <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
             <Button
               variant="ghost"
@@ -235,7 +287,58 @@
   </p>
 </div>
 
-<!-- Identity Editor Dialog -->
+<Dialog.Root bind:open={showSharedMailboxDialog}>
+  <Dialog.Content class="max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>{$_('identity.addSharedMailboxTitle')}</Dialog.Title>
+      <Dialog.Description>
+        {$_('identity.addSharedMailboxDescription')}
+      </Dialog.Description>
+    </Dialog.Header>
+
+    <form onsubmit={(e) => { e.preventDefault(); handleAddSharedMailbox() }} class="space-y-4">
+      <div class="space-y-2">
+        <Label for="sharedMailboxEmail">{$_('identity.sharedMailboxEmailLabel')}</Label>
+        <Input
+          id="sharedMailboxEmail"
+          type="email"
+          placeholder={$_('identity.sharedMailboxEmailPlaceholder')}
+          bind:value={sharedMailboxEmail}
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sharedMailboxDisplayName">{$_('identity.sharedMailboxDisplayNameLabel')}</Label>
+        <Input
+          id="sharedMailboxDisplayName"
+          type="text"
+          placeholder={$_('identity.sharedMailboxDisplayNamePlaceholder')}
+          bind:value={sharedMailboxDisplayName}
+        />
+        <p class="text-xs text-muted-foreground">
+          {$_('identity.sharedMailboxDisplayNameHelp')}
+        </p>
+      </div>
+
+      {#if sharedMailboxError}
+        <p class="text-sm text-destructive">{sharedMailboxError}</p>
+      {/if}
+
+      <Dialog.Footer>
+        <Button type="button" variant="ghost" onclick={() => showSharedMailboxDialog = false} disabled={addingSharedMailbox}>
+          {$_('common.cancel')}
+        </Button>
+        <Button type="submit" disabled={addingSharedMailbox}>
+          {#if addingSharedMailbox}
+            <Icon icon="mdi:loading" class="w-4 h-4 mr-2 animate-spin" />
+          {/if}
+          {$_('identity.addSharedMailboxButton')}
+        </Button>
+      </Dialog.Footer>
+    </form>
+  </Dialog.Content>
+</Dialog.Root>
+
 <IdentityEditor
   bind:open={showEditor}
   {accountId}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -665,7 +665,19 @@
     "addSeparator": "Add separator line before signature",
     "saveIdentityChanges": "Save Changes",
     "saveFailed": "Failed to save identity.",
-    "addEmailAddressButton": "Add Email Address"
+    "addEmailAddressButton": "Add Email Address",
+    "addSharedMailbox": "Add Shared Mailbox",
+    "addSharedMailboxTitle": "Add Shared Mailbox",
+    "addSharedMailboxDescription": "Add a Microsoft 365 shared mailbox using this account's existing sign-in.",
+    "sharedMailboxEmailLabel": "Shared mailbox email",
+    "sharedMailboxEmailPlaceholder": "shared@company.com",
+    "sharedMailboxDisplayNameLabel": "Display name",
+    "sharedMailboxDisplayNamePlaceholder": "Support Team",
+    "sharedMailboxDisplayNameHelp": "Used for the default sender identity of the shared mailbox.",
+    "sharedMailboxEmailRequired": "Shared mailbox email is required.",
+    "sharedMailboxEmailInvalid": "Enter a valid shared mailbox email address.",
+    "sharedMailboxAdded": "Shared mailbox added: {email}",
+    "addSharedMailboxButton": "Add Mailbox"
   },
   "security": {
     "smime": "S/MIME",

--- a/frontend/src/lib/i18n/locales/zh-CN.json
+++ b/frontend/src/lib/i18n/locales/zh-CN.json
@@ -660,7 +660,19 @@
     "addSeparator": "在签名前添加分隔线",
     "saveIdentityChanges": "保存更改",
     "saveFailed": "保存身份失败。",
-    "addEmailAddressButton": "添加电子邮件地址"
+    "addEmailAddressButton": "添加电子邮件地址",
+    "addSharedMailbox": "添加共享邮箱",
+    "addSharedMailboxTitle": "添加共享邮箱",
+    "addSharedMailboxDescription": "使用此账户现有的登录状态添加 Microsoft 365 共享邮箱。",
+    "sharedMailboxEmailLabel": "共享邮箱地址",
+    "sharedMailboxEmailPlaceholder": "shared@company.com",
+    "sharedMailboxDisplayNameLabel": "显示名称",
+    "sharedMailboxDisplayNamePlaceholder": "Support Team",
+    "sharedMailboxDisplayNameHelp": "用于共享邮箱默认发件身份的显示名称。",
+    "sharedMailboxEmailRequired": "共享邮箱地址为必填。",
+    "sharedMailboxEmailInvalid": "请输入有效的共享邮箱地址。",
+    "sharedMailboxAdded": "已添加共享邮箱：{email}",
+    "addSharedMailboxButton": "添加邮箱"
   },
   "security": {
     "smime": "S/MIME",

--- a/frontend/src/lib/i18n/locales/zh-HK.json
+++ b/frontend/src/lib/i18n/locales/zh-HK.json
@@ -660,7 +660,19 @@
     "addSeparator": "在簽名前加入分隔線",
     "saveIdentityChanges": "儲存變更",
     "saveFailed": "儲存身分失敗。",
-    "addEmailAddressButton": "新增電子郵件地址"
+    "addEmailAddressButton": "新增電子郵件地址",
+    "addSharedMailbox": "新增共享郵箱",
+    "addSharedMailboxTitle": "新增共享郵箱",
+    "addSharedMailboxDescription": "使用此帳戶現有的登入狀態新增 Microsoft 365 共享郵箱。",
+    "sharedMailboxEmailLabel": "共享郵箱地址",
+    "sharedMailboxEmailPlaceholder": "shared@company.com",
+    "sharedMailboxDisplayNameLabel": "顯示名稱",
+    "sharedMailboxDisplayNamePlaceholder": "Support Team",
+    "sharedMailboxDisplayNameHelp": "用於共享郵箱預設寄件身分的顯示名稱。",
+    "sharedMailboxEmailRequired": "共享郵箱地址為必填。",
+    "sharedMailboxEmailInvalid": "請輸入有效的共享郵箱地址。",
+    "sharedMailboxAdded": "已新增共享郵箱：{email}",
+    "addSharedMailboxButton": "新增郵箱"
   },
   "security": {
     "smime": "S/MIME",

--- a/frontend/src/lib/i18n/locales/zh-TW.json
+++ b/frontend/src/lib/i18n/locales/zh-TW.json
@@ -660,7 +660,19 @@
     "addSeparator": "在簽名前加入分隔線",
     "saveIdentityChanges": "儲存變更",
     "saveFailed": "儲存身分失敗。",
-    "addEmailAddressButton": "新增電子郵件地址"
+    "addEmailAddressButton": "新增電子郵件地址",
+    "addSharedMailbox": "新增共享信箱",
+    "addSharedMailboxTitle": "新增共享信箱",
+    "addSharedMailboxDescription": "使用此帳戶現有的登入狀態新增 Microsoft 365 共享信箱。",
+    "sharedMailboxEmailLabel": "共享信箱地址",
+    "sharedMailboxEmailPlaceholder": "shared@company.com",
+    "sharedMailboxDisplayNameLabel": "顯示名稱",
+    "sharedMailboxDisplayNamePlaceholder": "Support Team",
+    "sharedMailboxDisplayNameHelp": "用於共享信箱預設寄件身分的顯示名稱。",
+    "sharedMailboxEmailRequired": "共享信箱地址為必填。",
+    "sharedMailboxEmailInvalid": "請輸入有效的共享信箱地址。",
+    "sharedMailboxAdded": "已新增共享信箱：{email}",
+    "addSharedMailboxButton": "新增信箱"
   },
   "security": {
     "smime": "S/MIME",

--- a/frontend/src/lib/stores/accounts.svelte.ts
+++ b/frontend/src/lib/stores/accounts.svelte.ts
@@ -6,6 +6,7 @@ import {
   SyncAllComplete,
   CancelAllSyncs,
   AddAccount,
+  AddMicrosoftSharedMailbox,
   UpdateAccount,
   RemoveAccount,
   TestConnection,
@@ -404,6 +405,19 @@ class AccountStore {
     })
 
     // Start sync in background (don't await - let dialog close immediately)
+    this.syncAccount(newAccount.id).catch(err => {
+      console.error('Initial sync failed:', err)
+    })
+
+    return newAccount
+  }
+
+  async addMicrosoftSharedMailbox(primaryAccountId: string, sharedEmail: string, displayName: string): Promise<account.Account> {
+    const newAccount = await AddMicrosoftSharedMailbox(primaryAccountId, sharedEmail, displayName)
+
+    // Reload all accounts so settings/sidebar views immediately reflect the new mailbox.
+    await this.load()
+
     this.syncAccount(newAccount.id).catch(err => {
       console.error('Initial sync failed:', err)
     })

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -27,6 +27,8 @@ export function AddContactSource(arg1:carddav.SourceConfig):Promise<carddav.Sour
 
 export function AddImageAllowlist(arg1:string,arg2:string):Promise<void>;
 
+export function AddMicrosoftSharedMailbox(arg1:string,arg2:string,arg3:string):Promise<account.Account>;
+
 export function AddPGPKeyServer(arg1:string):Promise<void>;
 
 export function Archive(arg1:Array<string>):Promise<void>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -22,6 +22,10 @@ export function AddImageAllowlist(arg1, arg2) {
   return window['go']['app']['App']['AddImageAllowlist'](arg1, arg2);
 }
 
+export function AddMicrosoftSharedMailbox(arg1, arg2, arg3) {
+  return window['go']['app']['App']['AddMicrosoftSharedMailbox'](arg1, arg2, arg3);
+}
+
 export function AddPGPKeyServer(arg1) {
   return window['go']['app']['App']['AddPGPKeyServer'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -4,6 +4,9 @@ export namespace account {
 	    id: string;
 	    name: string;
 	    email: string;
+	    kind: string;
+	    provider: string;
+	    oauthSourceAccountId?: string;
 	    imapHost: string;
 	    imapPort: number;
 	    imapSecurity: string;
@@ -39,6 +42,9 @@ export namespace account {
 	        this.id = source["id"];
 	        this.name = source["name"];
 	        this.email = source["email"];
+	        this.kind = source["kind"];
+	        this.provider = source["provider"];
+	        this.oauthSourceAccountId = source["oauthSourceAccountId"];
 	        this.imapHost = source["imapHost"];
 	        this.imapPort = source["imapPort"];
 	        this.imapSecurity = source["imapSecurity"];
@@ -86,6 +92,9 @@ export namespace account {
 	    name: string;
 	    displayName: string;
 	    email: string;
+	    kind: string;
+	    provider: string;
+	    oauthSourceAccountId?: string;
 	    imapHost: string;
 	    imapPort: number;
 	    imapSecurity: string;
@@ -116,6 +125,9 @@ export namespace account {
 	        this.name = source["name"];
 	        this.displayName = source["displayName"];
 	        this.email = source["email"];
+	        this.kind = source["kind"];
+	        this.provider = source["provider"];
+	        this.oauthSourceAccountId = source["oauthSourceAccountId"];
 	        this.imapHost = source["imapHost"];
 	        this.imapPort = source["imapPort"];
 	        this.imapSecurity = source["imapSecurity"];

--- a/internal/account/model.go
+++ b/internal/account/model.go
@@ -22,11 +22,23 @@ const (
 	AuthOAuth2   AuthType = "oauth2"
 )
 
+// AccountKind represents how an account is provisioned.
+type AccountKind string
+
+const (
+	AccountKindPrimary AccountKind = "primary"
+	AccountKindShared  AccountKind = "shared"
+)
+
 // Account represents an email account configuration
 type Account struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Email string `json:"email"`
+
+	Kind                 AccountKind `json:"kind"`
+	Provider             string      `json:"provider"`
+	OAuthSourceAccountID string      `json:"oauthSourceAccountId,omitempty"`
 
 	// IMAP settings
 	IMAPHost     string       `json:"imapHost"`
@@ -152,6 +164,10 @@ type AccountConfig struct {
 	DisplayName string `json:"displayName"` // Name shown to email recipients
 	Email       string `json:"email"`
 
+	Kind                 AccountKind `json:"kind"`
+	Provider             string      `json:"provider"`
+	OAuthSourceAccountID string      `json:"oauthSourceAccountId,omitempty"`
+
 	IMAPHost     string       `json:"imapHost"`
 	IMAPPort     int          `json:"imapPort"`
 	IMAPSecurity SecurityType `json:"imapSecurity"`
@@ -216,6 +232,9 @@ func (c *AccountConfig) Validate() error {
 	}
 	if c.AuthType == "" {
 		c.AuthType = AuthPassword
+	}
+	if c.Kind == "" {
+		c.Kind = AccountKindPrimary
 	}
 	if c.SyncPeriodDays < 0 {
 		c.SyncPeriodDays = 30

--- a/internal/account/store.go
+++ b/internal/account/store.go
@@ -77,6 +77,9 @@ func (s *Store) Create(config *AccountConfig) (*Account, error) {
 		ID:                       uuid.New().String(),
 		Name:                     config.Name,
 		Email:                    config.Email,
+		Kind:                     config.Kind,
+		Provider:                 config.Provider,
+		OAuthSourceAccountID:     config.OAuthSourceAccountID,
 		IMAPHost:                 config.IMAPHost,
 		IMAPPort:                 config.IMAPPort,
 		IMAPSecurity:             config.IMAPSecurity,
@@ -104,7 +107,7 @@ func (s *Store) Create(config *AccountConfig) (*Account, error) {
 
 	_, err = s.db.Exec(`
 		INSERT INTO accounts (
-			id, name, email,
+			id, name, email, kind, provider, oauth_source_account_id,
 			imap_host, imap_port, imap_security,
 			smtp_host, smtp_port, smtp_security,
 			auth_type, username,
@@ -114,9 +117,9 @@ func (s *Store) Create(config *AccountConfig) (*Account, error) {
 			spam_folder_path, archive_folder_path, all_mail_folder_path,
 			starred_folder_path,
 			created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		account.ID, account.Name, account.Email,
+		account.ID, account.Name, account.Email, account.Kind, account.Provider, nullableString(account.OAuthSourceAccountID),
 		account.IMAPHost, account.IMAPPort, account.IMAPSecurity,
 		account.SMTPHost, account.SMTPPort, account.SMTPSecurity,
 		account.AuthType, account.Username,
@@ -156,9 +159,9 @@ func (s *Store) Create(config *AccountConfig) (*Account, error) {
 // Get retrieves an account by ID
 func (s *Store) Get(id string) (*Account, error) {
 	account := &Account{}
-	var sentPath, draftsPath, trashPath, spamPath, archivePath, allMailPath, starredPath sql.NullString
+	var sentPath, draftsPath, trashPath, spamPath, archivePath, allMailPath, starredPath, oauthSourceAccountID sql.NullString
 	err := s.db.QueryRow(`
-		SELECT id, name, email,
+		SELECT id, name, email, kind, provider, oauth_source_account_id,
 			imap_host, imap_port, imap_security,
 			smtp_host, smtp_port, smtp_security,
 			auth_type, username,
@@ -170,7 +173,7 @@ func (s *Store) Get(id string) (*Account, error) {
 			created_at, updated_at
 		FROM accounts WHERE id = ?
 	`, id).Scan(
-		&account.ID, &account.Name, &account.Email,
+		&account.ID, &account.Name, &account.Email, &account.Kind, &account.Provider, &oauthSourceAccountID,
 		&account.IMAPHost, &account.IMAPPort, &account.IMAPSecurity,
 		&account.SMTPHost, &account.SMTPPort, &account.SMTPSecurity,
 		&account.AuthType, &account.Username,
@@ -188,6 +191,7 @@ func (s *Store) Get(id string) (*Account, error) {
 		return nil, fmt.Errorf("failed to get account: %w", err)
 	}
 	// Map nullable strings to account fields
+	account.OAuthSourceAccountID = oauthSourceAccountID.String
 	account.SentFolderPath = sentPath.String
 	account.DraftsFolderPath = draftsPath.String
 	account.TrashFolderPath = trashPath.String
@@ -201,7 +205,7 @@ func (s *Store) Get(id string) (*Account, error) {
 // List retrieves all accounts ordered by order_index
 func (s *Store) List() ([]*Account, error) {
 	rows, err := s.db.Query(`
-		SELECT id, name, email,
+		SELECT id, name, email, kind, provider, oauth_source_account_id,
 			imap_host, imap_port, imap_security,
 			smtp_host, smtp_port, smtp_security,
 			auth_type, username,
@@ -221,9 +225,9 @@ func (s *Store) List() ([]*Account, error) {
 	var accounts []*Account
 	for rows.Next() {
 		account := &Account{}
-		var sentPath, draftsPath, trashPath, spamPath, archivePath, allMailPath, starredPath sql.NullString
+		var sentPath, draftsPath, trashPath, spamPath, archivePath, allMailPath, starredPath, oauthSourceAccountID sql.NullString
 		err := rows.Scan(
-			&account.ID, &account.Name, &account.Email,
+			&account.ID, &account.Name, &account.Email, &account.Kind, &account.Provider, &oauthSourceAccountID,
 			&account.IMAPHost, &account.IMAPPort, &account.IMAPSecurity,
 			&account.SMTPHost, &account.SMTPPort, &account.SMTPSecurity,
 			&account.AuthType, &account.Username,
@@ -238,6 +242,7 @@ func (s *Store) List() ([]*Account, error) {
 			return nil, fmt.Errorf("failed to scan account: %w", err)
 		}
 		// Map nullable strings to account fields
+		account.OAuthSourceAccountID = oauthSourceAccountID.String
 		account.SentFolderPath = sentPath.String
 		account.DraftsFolderPath = draftsPath.String
 		account.TrashFolderPath = trashPath.String
@@ -266,7 +271,7 @@ func (s *Store) Update(id string, config *AccountConfig) (*Account, error) {
 	now := time.Now()
 	_, err = s.db.Exec(`
 		UPDATE accounts SET
-			name = ?, email = ?,
+			name = ?, email = ?, provider = ?,
 			imap_host = ?, imap_port = ?, imap_security = ?,
 			smtp_host = ?, smtp_port = ?, smtp_security = ?,
 			auth_type = ?, username = ?,
@@ -278,7 +283,7 @@ func (s *Store) Update(id string, config *AccountConfig) (*Account, error) {
 			updated_at = ?
 		WHERE id = ?
 	`,
-		config.Name, config.Email,
+		config.Name, config.Email, config.Provider,
 		config.IMAPHost, config.IMAPPort, config.IMAPSecurity,
 		config.SMTPHost, config.SMTPPort, config.SMTPSecurity,
 		config.AuthType, config.Username,
@@ -293,16 +298,17 @@ func (s *Store) Update(id string, config *AccountConfig) (*Account, error) {
 		return nil, fmt.Errorf("failed to update account: %w", err)
 	}
 
-	// Update the default identity's name (display name for sending)
+	// Keep the default identity aligned with the account's primary mailbox settings.
 	_, err = s.db.Exec(`
-		UPDATE identities SET name = ? WHERE account_id = ? AND is_default = 1
-	`, config.DisplayName, id)
+		UPDATE identities SET email = ?, name = ?, updated_at = ? WHERE account_id = ? AND is_default = 1
+	`, config.Email, config.DisplayName, now, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update default identity: %w", err)
 	}
 
 	existing.Name = config.Name
 	existing.Email = config.Email
+	existing.Provider = config.Provider
 	existing.IMAPHost = config.IMAPHost
 	existing.IMAPPort = config.IMAPPort
 	existing.IMAPSecurity = config.IMAPSecurity

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -690,4 +690,28 @@ var migrations = []Migration{
 				('https://pgp.mit.edu', 2);
 		`,
 	},
+	{
+		Version: 26,
+		SQL: `
+			-- Linked/shared mailbox support
+			ALTER TABLE accounts ADD COLUMN kind TEXT NOT NULL DEFAULT 'primary';
+			ALTER TABLE accounts ADD COLUMN provider TEXT NOT NULL DEFAULT '';
+			ALTER TABLE accounts ADD COLUMN oauth_source_account_id TEXT REFERENCES accounts(id) ON DELETE CASCADE;
+
+			UPDATE accounts
+			SET provider = 'microsoft'
+			WHERE provider = ''
+				AND auth_type = 'oauth2'
+				AND imap_host = 'outlook.office365.com';
+
+			UPDATE accounts
+			SET provider = 'google'
+			WHERE provider = ''
+				AND auth_type = 'oauth2'
+				AND imap_host = 'imap.gmail.com';
+
+			CREATE INDEX IF NOT EXISTS idx_accounts_oauth_source_account ON accounts(oauth_source_account_id);
+			CREATE INDEX IF NOT EXISTS idx_accounts_kind_provider ON accounts(kind, provider);
+		`,
+	},
 }


### PR DESCRIPTION
## Summary
- add Microsoft shared mailboxes as linked logical accounts that reuse OAuth tokens from a primary Microsoft account
- add a settings UI flow to create shared mailboxes from the account Identity tab
- refresh settings/account state immediately after mailbox creation and localize the new dialog copy
- authenticate SMTP for Microsoft shared mailboxes using the source account username while preserving the shared mailbox sender address

## What Changed
- Added account metadata for linked mailboxes via `kind`, `provider`, and `oauthSourceAccountId`
- Added a database migration for linked/shared mailbox support and backfilled provider values for existing OAuth accounts
- Added `AddMicrosoftSharedMailbox` in the backend to validate access against Microsoft IMAP before saving the mailbox
- Reused parent-account OAuth tokens for shared mailboxes through the central IMAP/SMTP OAuth path
- Added a Microsoft shared-mailbox SMTP auth helper so compose/read-receipt flows authenticate as the source mailbox user while still sending from the shared mailbox address
- Added a new `Add Shared Mailbox` action in Settings > Accounts > Edit Account > Identity
- Added i18n strings for the new dialog in English, Simplified Chinese, Traditional Chinese (HK), and Traditional Chinese (TW)
- Reloaded the account store after shared mailbox creation so the settings view and sidebar update immediately

## User Flow
1. Add/sign in to a Microsoft 365 account using OAuth.
2. Open `Settings` > `Accounts`.
3. Edit the Microsoft account.
4. Open the `Identity` tab.
5. Click `Add Shared Mailbox`.
6. Enter the shared mailbox email and optional display name.
7. Add the mailbox.
8. Compose from the shared mailbox account and send using the shared mailbox sender address.

Expected behavior:
- the mailbox is added as its own synced account/mailbox entry
- it appears in the settings account list and sidebar immediately
- initial sync starts automatically
- the shared mailbox gets its own default sender identity
- sending from the shared mailbox works when Exchange grants the source user the required shared mailbox permissions

## Scope
- Microsoft-only for now
- shared mailboxes can only be added from a primary Microsoft OAuth account
- shared mailboxes reuse the primary account's OAuth tokens rather than storing separate OAuth credentials

## Validation
- `npm run check`
- `npm run build`
- `PATH=/home/tom/.local/go/bin:$PATH go test ./...`
- manual validation against Microsoft 365 shared mailbox access, including send-from-shared-mailbox via SMTP OAuth

## Notes
- The implementation models shared mailboxes as separate logical accounts rather than sender aliases only. This keeps folder sync, unread counts, and compose flows aligned with the existing account-based architecture.
- The released Aerion app already works with Microsoft's existing OAuth setup. This change extends Aerion to add shared mailboxes in the local codebase without changing the overall Microsoft account sign-in flow.
- In practice, Microsoft shared mailbox SMTP submission required authenticating with the source account username while preserving the shared mailbox sender identity.
