### PR TITLE
Enable native right-click menu in email body and composer

### DIFF
--- a/frontend/src/lib/components/composer/composerEditor.ts
+++ b/frontend/src/lib/components/composer/composerEditor.ts
@@ -174,6 +174,7 @@ export function createComposerEditor(
     editorProps: {
       attributes: {
         class: 'composer-editor focus:outline-none min-h-[200px] p-3',
+        spellcheck: 'true',
       },
       // Handle paste events for images
       handlePaste: (view, event) => {

--- a/frontend/src/lib/components/viewer/EmailBody.svelte
+++ b/frontend/src/lib/components/viewer/EmailBody.svelte
@@ -37,12 +37,6 @@
   let tooltipX = $state(0)
   let tooltipY = $state(0)
 
-  // Link context menu state
-  let linkContextMenuVisible = $state(false)
-  let linkContextMenuUrl = $state('')
-  let linkContextMenuX = $state(0)
-  let linkContextMenuY = $state(0)
-  
   // Derived state
   let hasRemoteImages = $derived(checkForRemoteImages(bodyHtml))
   let hasCidReferences = $derived(bodyHtml ? /src=["']cid:([^"']+)["']/i.test(bodyHtml) : false)
@@ -187,21 +181,6 @@
         var link = e.target.closest('a');
         if (link && link.href) {
           window.parent.postMessage({ type: 'link-hover-end' }, '*');
-        }
-      });
-
-      // Handle right-click context menu for links
-      document.addEventListener('contextmenu', function(e) {
-        var link = e.target.closest('a');
-        if (link && link.href) {
-          e.preventDefault();
-          var rect = link.getBoundingClientRect();
-          window.parent.postMessage({
-            type: 'link-contextmenu',
-            url: link.href,
-            x: e.clientX,
-            y: e.clientY
-          }, '*');
         }
       });
 
@@ -384,15 +363,6 @@ ${processedHtml}
     } else if (event.data?.type === 'link-hover-end') {
       // Hide tooltip
       tooltipVisible = false
-    } else if (event.data?.type === 'link-contextmenu') {
-      // Show context menu for link - adjust coordinates relative to iframe position
-      if (iframeElement) {
-        const iframeRect = iframeElement.getBoundingClientRect()
-        linkContextMenuUrl = event.data.url
-        linkContextMenuX = iframeRect.left + event.data.x
-        linkContextMenuY = iframeRect.top + event.data.y
-        linkContextMenuVisible = true
-      }
     }
   }
 
@@ -574,17 +544,6 @@ ${processedHtml}
     return escaped
   }
 
-  // Copy link to clipboard
-  async function copyLinkToClipboard() {
-    if (linkContextMenuUrl) {
-      try {
-        await navigator.clipboard.writeText(linkContextMenuUrl)
-        linkContextMenuVisible = false
-      } catch (err) {
-        console.error('[EmailBody] Failed to copy link:', err)
-      }
-    }
-  }
 </script>
 
 <div class="email-body relative">
@@ -652,39 +611,4 @@ ${processedHtml}
       {tooltipUrl}
     </div>
   {/if}
-
-  <!-- Link context menu -->
-  {#if linkContextMenuVisible}
-    <div
-      class="fixed z-50 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 min-w-[160px]"
-      style="left: {linkContextMenuX}px; top: {linkContextMenuY}px;"
-      role="menu"
-    >
-      <button
-        class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-        onclick={copyLinkToClipboard}
-      >
-        <Icon icon="mdi:content-copy" class="w-4 h-4" />
-        {$_('viewer.copyLink')}
-      </button>
-      <button
-        class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-        onclick={() => linkContextMenuVisible = false}
-      >
-        <Icon icon="mdi:close" class="w-4 h-4" />
-        {$_('common.cancel')}
-      </button>
-    </div>
-  {/if}
 </div>
-
-<!-- Click outside to close context menu -->
-{#if linkContextMenuVisible}
-  <button
-    type="button"
-    class="fixed inset-0 z-40 cursor-default"
-    aria-label={$_('aria.closeContextMenu')}
-    onclick={() => linkContextMenuVisible = false}
-    onkeydown={(e) => { if (e.key === 'Escape') linkContextMenuVisible = false }}
-  ></button>
-{/if}

--- a/main.go
+++ b/main.go
@@ -116,8 +116,9 @@ func runMainMode(mailtoData *app.MailtoData, rawMailtoArg string) {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
-		OnStartup:        application.Startup,
+		BackgroundColour:         &options.RGBA{R: 27, G: 38, B: 54, A: 1},
+		EnableDefaultContextMenu: true,
+		OnStartup:                application.Startup,
 		OnDomReady: func(ctx context.Context) {
 			platform.NotifyStartupComplete()
 		},
@@ -209,9 +210,10 @@ func runComposerMode() {
 			// so we can rewrite "/" to "/composer.html"
 			Handler: composerAssetHandler,
 		},
-		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
-		OnStartup:        composerApp.Startup,
-		OnShutdown:       composerApp.Shutdown,
+		BackgroundColour:         &options.RGBA{R: 27, G: 38, B: 54, A: 1},
+		EnableDefaultContextMenu: true,
+		OnStartup:                composerApp.Startup,
+		OnShutdown:               composerApp.Shutdown,
 		Bind: []interface{}{
 			composerApp,
 		},


### PR DESCRIPTION
## Summary
- enable Wails' default/native context menu in both the main window and detached composer
- stop overriding right-click inside the email body iframe so selected text and links can use the platform webview menu
- keep the change scoped to native context-menu behavior only

Closes #77

## User-visible behavior
- right-clicking selected text in received email bodies now shows the native webview context menu instead of doing nothing
- right-clicking in the composer now consistently uses the native edit menu in production builds
- behavior follows the host platform's webview, so available items may vary slightly across Linux, macOS, and Windows

## Technical model
- Wails disables the default webview context menu in production unless `EnableDefaultContextMenu` is set
- the email body iframe previously intercepted `contextmenu` for links and replaced it with an app-specific menu, which also prevented the native menu from appearing in that surface
- this change enables the native menu at the Wails app level and removes the iframe-specific override so WebKitGTK/WebView2/WebKit can provide the standard menu

## Validation
- `npm run check --prefix frontend`
- `npm run build --prefix frontend`
- `PATH=/home/tom/.local/go/bin:$PATH go test ./...`

## Scope and limitations
- this PR does not add custom Aerion-specific context-menu actions or spellchecking
- menu contents remain platform-native and may differ by OS/webview
- the change is intentionally limited to restoring native right-click behavior in the email body and composer surfaces
