### PR TITLE
feat: command palette (Cmd+Shift+P) + keyboard shortcuts reference

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,6 +11,8 @@
   import ToastContainer from './lib/components/ui/toast/ToastContainer.svelte'
   import TermsDialog from './lib/components/TermsDialog.svelte'
   import CertificateDialog from './lib/components/settings/CertificateDialog.svelte'
+  import CommandPalette, { type Command } from './lib/components/common/CommandPalette.svelte'
+  import ShortcutsDialog from './lib/components/common/ShortcutsDialog.svelte'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import { accountStore } from '$lib/stores/accounts.svelte'
   import { addToast } from '$lib/stores/toast'
@@ -65,6 +67,8 @@
 
   // Composer state
   let showComposer = $state(false)
+  let showCommandPalette = $state(false)
+  let showShortcuts = $state(false)
   let composerAccountId = $state<string | null>(null)
   let composerInitialMessage = $state<smtp.ComposeMessage | null>(null)
   let composerDraftId = $state<string | null>(null)
@@ -749,6 +753,14 @@
           e.preventDefault()
           handleCompose()
           return
+        case 'p':
+          // Cmd/Ctrl+Shift+P opens the command palette (search + run message actions)
+          if (e.shiftKey) {
+            e.preventDefault()
+            showCommandPalette = true
+            return
+          }
+          break
         case 'r': {
           if (!hasConversation) return
           e.preventDefault()
@@ -1232,6 +1244,67 @@
       addToast({ type: 'error', message: $_('toast.undoFailed') })
     }
   }
+
+  // Resolve the messages a command should act on: checked set if any, else the
+  // keyboard-focused conversation.
+  function paletteTargetIds(): string[] {
+    if (!messageListRef) return []
+    return messageListRef.hasCheckedMessages()
+      ? messageListRef.getCheckedMessageIds()
+      : messageListRef.getSelectedMessageIds()
+  }
+
+  const cmdMod = (typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)) ? '⌘' : 'Ctrl'
+
+  // Command palette entries. Message actions are enabled only when something is selected.
+  const paletteCommands = $derived<Command[]>([
+    { id: 'compose', label: $_('commandPalette.newMessage'), icon: 'feather:edit', hint: `${cmdMod}N`, run: handleCompose },
+    {
+      id: 'markRead', label: $_('commandPalette.markRead'), icon: 'feather:check-circle',
+      enabled: selectedThreadId !== null,
+      run: () => { const ids = paletteTargetIds(); if (ids.length) handleBulkMarkRead(ids) },
+    },
+    {
+      id: 'markUnread', label: $_('commandPalette.markUnread'), icon: 'feather:mail',
+      enabled: selectedThreadId !== null,
+      run: () => { const ids = paletteTargetIds(); if (ids.length) handleBulkMarkUnread(ids) },
+    },
+    {
+      id: 'star', label: $_('commandPalette.toggleStar'), icon: 'feather:star', keywords: 'favorite flag',
+      enabled: selectedThreadId !== null,
+      run: () => {
+        const ids = paletteTargetIds()
+        if (!ids.length) return
+        const shouldStar = messageListRef?.hasCheckedMessages()
+          ? messageListRef.getCheckedHasUnstarred()
+          : !(messageListRef?.isSelectedStarred() ?? false)
+        handleBulkToggleStar(ids, shouldStar)
+      },
+    },
+    {
+      id: 'archive', label: $_('commandPalette.archive'), icon: 'feather:archive',
+      enabled: selectedThreadId !== null,
+      run: () => { const ids = paletteTargetIds(); if (ids.length) handleBulkArchive(ids) },
+    },
+    {
+      id: 'move', label: $_('commandPalette.moveTo'), icon: 'feather:folder', hint: 'm', keywords: 'folder',
+      enabled: selectedThreadId !== null,
+      run: () => messageListRef?.openMoveTo(),
+    },
+    {
+      id: 'spam', label: $_('commandPalette.markSpam'), icon: 'feather:alert-octagon', keywords: 'junk',
+      enabled: selectedThreadId !== null,
+      run: () => { const ids = paletteTargetIds(); if (ids.length) handleBulkSpam(ids) },
+    },
+    {
+      id: 'delete', label: $_('commandPalette.delete'), icon: 'feather:trash-2', keywords: 'trash remove',
+      enabled: selectedThreadId !== null,
+      run: () => { const ids = paletteTargetIds(); if (ids.length) messageListRef?.requestDelete(ids) },
+    },
+    { id: 'undo', label: $_('commandPalette.undo'), icon: 'feather:rotate-ccw', hint: `${cmdMod}Z`, run: handleUndo },
+    { id: 'refresh', label: $_('commandPalette.refresh'), icon: 'feather:refresh-cw', hint: `${cmdMod}R`, run: () => sidebarRef?.syncAllAccounts() },
+    { id: 'shortcuts', label: $_('commandPalette.shortcuts'), icon: 'feather:command', keywords: 'keyboard help', run: () => { showShortcuts = true } },
+  ])
 </script>
 
 <svelte:window onmousemove={handleMouseMove} onmouseup={handleMouseUp} onkeydown={handleGlobalKeyDown} onkeyup={handleGlobalKeyUp} />
@@ -1368,6 +1441,10 @@
 
 <!-- Toast notifications -->
 <ToastContainer />
+
+<CommandPalette bind:open={showCommandPalette} commands={paletteCommands} />
+
+<ShortcutsDialog bind:open={showShortcuts} />
 
 <!-- Composer Modal -->
 {#if showComposer && composerAccountId}

--- a/frontend/src/lib/components/common/CommandPalette.svelte
+++ b/frontend/src/lib/components/common/CommandPalette.svelte
@@ -1,0 +1,157 @@
+<script module lang="ts">
+  export interface Command {
+    id: string
+    label: string
+    /** Right-aligned hint, e.g. a keyboard shortcut */
+    hint?: string
+    /** Iconify icon name */
+    icon?: string
+    /** Extra search terms */
+    keywords?: string
+    /** Whether the command is currently actionable; non-actionable ones are hidden */
+    enabled?: boolean
+    run: () => void
+  }
+</script>
+
+<script lang="ts">
+  import Icon from '@iconify/svelte'
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { dialogGuardOpen, dialogGuardClose } from '$lib/stores/dialogGuard'
+  import { _ } from '$lib/i18n'
+
+  interface Props {
+    open: boolean
+    commands: Command[]
+  }
+
+  let { open = $bindable(false), commands }: Props = $props()
+
+  let query = $state('')
+  let focusedIndex = $state(0)
+  let active = $state(false)
+  let inputEl = $state<HTMLInputElement | null>(null)
+  let listEl = $state<HTMLDivElement | null>(null)
+
+  const visibleCommands = $derived(commands.filter((c) => c.enabled !== false))
+
+  const filtered = $derived.by(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return visibleCommands
+    return visibleCommands.filter((c) =>
+      c.label.toLowerCase().includes(q) || (c.keywords ?? '').toLowerCase().includes(q)
+    )
+  })
+
+  // Activate dialog guard while open so background shortcuts don't fire.
+  $effect(() => {
+    if (open) {
+      dialogGuardOpen()
+      return () => dialogGuardClose()
+    }
+  })
+
+  // Reset state on open; focus the input.
+  $effect(() => {
+    if (!open) {
+      active = false
+      query = ''
+      return
+    }
+    focusedIndex = 0
+    active = false
+    const timer = setTimeout(() => {
+      active = true
+      inputEl?.focus()
+    }, 0)
+    return () => clearTimeout(timer)
+  })
+
+  // Keep focus in range as the filter changes.
+  $effect(() => {
+    void query
+    if (focusedIndex > filtered.length - 1) focusedIndex = Math.max(0, filtered.length - 1)
+  })
+
+  // Scroll focused row into view.
+  $effect(() => {
+    if (!listEl) return
+    const rows = listEl.querySelectorAll('[data-command-row]')
+    ;(rows[focusedIndex] as HTMLElement | undefined)?.scrollIntoView({ block: 'nearest' })
+  })
+
+  function runAt(index: number) {
+    const cmd = filtered[index]
+    if (!cmd) return
+    open = false
+    // Run after close so the palette tears down cleanly first.
+    queueMicrotask(() => cmd.run())
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!active || !open) return
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        e.stopPropagation()
+        if (filtered.length > 0) focusedIndex = (focusedIndex + 1) % filtered.length
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        e.stopPropagation()
+        if (filtered.length > 0) focusedIndex = (focusedIndex - 1 + filtered.length) % filtered.length
+        break
+      case 'Enter':
+        e.preventDefault()
+        e.stopPropagation()
+        runAt(focusedIndex)
+        break
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<Dialog.Root bind:open>
+  <Dialog.Content class="max-w-lg p-0 gap-0 overflow-hidden shadow-2xl rounded-2xl sm:rounded-2xl" showOverlay={false} showClose={false}>
+    <!-- Search input -->
+    <div class="relative border-b border-border">
+      <Icon icon="feather:search" class="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        placeholder={$_('commandPalette.placeholder')}
+        class="flex h-12 w-full bg-transparent pl-11 pr-4 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+      />
+    </div>
+
+    <!-- Command list -->
+    <div class="max-h-80 overflow-y-auto py-1 scrollbar-thin" bind:this={listEl} role="listbox">
+      {#if filtered.length === 0}
+        <div class="px-4 py-6 text-center text-sm text-muted-foreground">
+          {$_('commandPalette.noResults')}
+        </div>
+      {:else}
+        {#each filtered as cmd, i (cmd.id)}
+          <button
+            type="button"
+            role="option"
+            data-command-row
+            aria-selected={i === focusedIndex}
+            class="w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors {i === focusedIndex ? 'bg-primary/10 text-primary' : 'hover:bg-muted/50'}"
+            onmousemove={() => (focusedIndex = i)}
+            onclick={() => runAt(i)}
+          >
+            {#if cmd.icon}
+              <Icon icon={cmd.icon} class="h-4 w-4 shrink-0 {i === focusedIndex ? 'text-primary' : 'text-muted-foreground'}" />
+            {/if}
+            <span class="flex-1 truncate">{cmd.label}</span>
+            {#if cmd.hint}
+              <span class="shrink-0 text-xs text-muted-foreground">{cmd.hint}</span>
+            {/if}
+          </button>
+        {/each}
+      {/if}
+    </div>
+  </Dialog.Content>
+</Dialog.Root>

--- a/frontend/src/lib/components/common/FolderPickerDialog.svelte
+++ b/frontend/src/lib/components/common/FolderPickerDialog.svelte
@@ -8,6 +8,7 @@
   // @ts-ignore - wailsjs path
   import { GetFolders } from '../../../../wailsjs/go/app/App'
   import { _ } from '$lib/i18n'
+  import { getMoveSuggestions } from '$lib/stores/moveSuggestions'
 
   interface Props {
     open: boolean
@@ -15,7 +16,8 @@
     initialAccountId: string
     accounts: account.Account[]
     excludeFolderId?: string
-    onSelect: (folderId: string, folderName: string, accountId: string) => void
+    senderEmail?: string
+    onSelect: (folderId: string, folderName: string, accountId: string, folderPath?: string) => void
   }
 
   let {
@@ -24,6 +26,7 @@
     initialAccountId,
     accounts,
     excludeFolderId = '',
+    senderEmail = '',
     onSelect,
   }: Props = $props()
 
@@ -86,6 +89,19 @@
     [...specialFolders, ...customFolders].sort((a, b) => a.path.localeCompare(b.path))
   )
 
+  const suggestedFolderIds = $derived(
+    new Set(
+      getMoveSuggestions(senderEmail, allFolders, selectedAccountId)
+        .map((suggestion) => suggestion.folderId)
+    )
+  )
+
+  const suggestedFolders = $derived(
+    getMoveSuggestions(senderEmail, allFolders, selectedAccountId)
+      .map((suggestion) => allFolders.find((f) => f.id === suggestion.folderId))
+      .filter((f): f is folder.Folder => !!f)
+  )
+
   // Detect the IMAP delimiter from folder paths
   const delimiter = $derived(() => {
     for (const f of allFolders) {
@@ -113,7 +129,12 @@
   // Filtered folders when searching
   const isSearching = $derived(searchQuery.trim().length > 0)
   const displayFolders = $derived(() => {
-    if (!isSearching) return allFolders
+    if (!isSearching) {
+      return [
+        ...suggestedFolders,
+        ...allFolders.filter((f) => !suggestedFolderIds.has(f.id)),
+      ]
+    }
     const query = searchQuery.trim().toLowerCase()
     return allFolders.filter(f =>
       f.name.toLowerCase().includes(query) || f.path.toLowerCase().includes(query)
@@ -189,7 +210,7 @@
         e.stopPropagation()
         if (focusedIndex >= 0 && focusedIndex < folders.length) {
           const f = folders[focusedIndex]
-          onSelect(f.id, f.name, selectedAccountId)
+          onSelect(f.id, f.name, selectedAccountId, f.path)
         }
         break
     }
@@ -199,7 +220,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <Dialog.Root bind:open>
-  <Dialog.Content class="max-w-sm">
+  <Dialog.Content class="max-w-sm shadow-2xl" showOverlay={false}>
     <Dialog.Header>
       <Dialog.Title>{title}</Dialog.Title>
     </Dialog.Header>
@@ -258,13 +279,16 @@
             aria-selected={i === focusedIndex}
             class="w-full flex items-center gap-2 py-2 pr-3 text-left text-sm hover:bg-muted/50 transition-colors {i === focusedIndex ? 'bg-muted/50' : ''}"
             style="padding-left: {12 + depth * 16}px"
-            onclick={() => onSelect(f.id, f.name, selectedAccountId)}
+            onclick={() => onSelect(f.id, f.name, selectedAccountId, f.path)}
           >
             <Icon icon={getFolderIcon(f.type)} class="h-4 w-4 shrink-0" />
             {#if isSearching}
               <span class="truncate">{formatPath(f.path)}</span>
             {:else}
               <span class="truncate">{f.name}</span>
+            {/if}
+            {#if !isSearching && suggestedFolderIds.has(f.id)}
+              <span class="ml-auto text-[11px] text-primary">{$_('contextMenu.suggested')}</span>
             {/if}
           </button>
         {/each}

--- a/frontend/src/lib/components/common/MessageContextMenu.svelte
+++ b/frontend/src/lib/components/common/MessageContextMenu.svelte
@@ -29,6 +29,7 @@
   import type { Snippet } from 'svelte'
   import { _ } from '$lib/i18n'
   import { dialogGuardOpen, dialogGuardClose } from '$lib/stores/dialogGuard'
+  import { learnMoveSuggestion } from '$lib/stores/moveSuggestions'
 
   interface Props {
     messageIds: string[]
@@ -37,8 +38,10 @@
     folderType: string
     isStarred: boolean
     isRead: boolean
+    senderEmail?: string
     onActionComplete?: (autoSelectNext?: boolean) => void
     onReply?: (mode: 'reply' | 'reply-all' | 'forward', messageId: string) => void
+    onSelectMode?: () => void
     onOpenChange?: (open: boolean) => void
     children?: Snippet
   }
@@ -50,8 +53,10 @@
     folderType,
     isStarred,
     isRead,
+    senderEmail = '',
     onActionComplete,
     onReply,
+    onSelectMode,
     onOpenChange,
     children,
   }: Props = $props()
@@ -247,16 +252,21 @@
     showFolderPicker = true
   }
 
-  function handleFolderSelected(folderId: string, folderName: string, _destAccountId: string) {
+  function handleFolderSelected(folderId: string, folderName: string, destAccountId: string, folderPath?: string) {
     showFolderPicker = false
     switch (folderPickerMode) {
       case 'move':
+        learnMoveSuggestion(senderEmail, { accountId: destAccountId, folderId, folderName, folderPath })
         handleMoveTo(folderId, folderName)
         break
       case 'copy':
         handleCopyTo(folderId, folderName)
         break
     }
+  }
+
+  function handleSelectMode() {
+    onSelectMode?.()
   }
 
   async function handleMoveTo(destFolderId: string, folderName: string) {
@@ -335,6 +345,11 @@
       {$_('contextMenu.copyTo')}
     </ContextMenuItem>
 
+    <ContextMenuItem onSelect={handleSelectMode}>
+      <Icon icon="mdi:checkbox-marked-outline" class="mr-2 h-4 w-4" />
+      {$_('contextMenu.select')}
+    </ContextMenuItem>
+
     <ContextMenuSeparator />
 
     <!-- Flag actions -->
@@ -373,5 +388,6 @@
   initialAccountId={accountId}
   {accounts}
   excludeFolderId={currentFolderId}
+  {senderEmail}
   onSelect={handleFolderSelected}
 />

--- a/frontend/src/lib/components/common/ShortcutsDialog.svelte
+++ b/frontend/src/lib/components/common/ShortcutsDialog.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { dialogGuardOpen, dialogGuardClose } from '$lib/stores/dialogGuard'
+
+  interface Props {
+    open: boolean
+  }
+
+  let { open = $bindable(false) }: Props = $props()
+
+  $effect(() => {
+    if (open) {
+      dialogGuardOpen()
+      return () => dialogGuardClose()
+    }
+  })
+
+  const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+  const mod = isMac ? '⌘' : 'Ctrl'
+  const shift = isMac ? '⇧' : 'Shift'
+  const alt = isMac ? '⌥' : 'Alt'
+
+  interface Shortcut {
+    keys: string[]
+    label: string
+  }
+  interface Group {
+    title: string
+    items: Shortcut[]
+  }
+
+  const groups: Group[] = [
+    {
+      title: 'General',
+      items: [
+        { keys: [mod, 'K'], label: 'Open command palette' },
+        { keys: [mod, 'N'], label: 'New message' },
+        { keys: [mod, 'Z'], label: 'Undo last action' },
+        { keys: [mod, 'R'], label: 'Refresh / sync all' },
+        { keys: [mod, ','], label: 'Settings' },
+        { keys: [mod, 'Q'], label: 'Quit' },
+      ],
+    },
+    {
+      title: 'Navigation',
+      items: [
+        { keys: ['↑', '↓'], label: 'Move between messages' },
+        { keys: ['j', 'k'], label: 'Move between messages' },
+        { keys: ['Enter'], label: 'Open selected message' },
+        { keys: ['Space'], label: 'Toggle checkbox' },
+        { keys: [alt, '←'], label: 'Focus previous pane' },
+        { keys: [alt, '→'], label: 'Focus next pane' },
+        { keys: [alt, '↑'], label: 'Previous folder' },
+        { keys: [alt, '↓'], label: 'Next folder' },
+        { keys: ['Esc'], label: 'Close / clear selection' },
+      ],
+    },
+    {
+      title: 'Message actions',
+      items: [
+        { keys: ['c'], label: 'Compose' },
+        { keys: ['m'], label: 'Move to folder' },
+        { keys: ['s'], label: 'Star / unstar' },
+        { keys: ['u'], label: 'Toggle read / unread' },
+        { keys: [mod, 'J'], label: 'Mark as spam' },
+        { keys: ['Delete'], label: 'Move to trash' },
+        { keys: [shift, 'Delete'], label: 'Delete permanently' },
+        { keys: ['f'], label: 'Focus thread' },
+        { keys: [shift, 'F'], label: 'Focus single message' },
+      ],
+    },
+    {
+      title: 'Reply & search',
+      items: [
+        { keys: [mod, 'R'], label: 'Reply' },
+        { keys: [mod, shift, 'R'], label: 'Reply all' },
+        { keys: [mod, 'F'], label: 'Forward' },
+        { keys: [mod, 'S'], label: 'Search messages' },
+        { keys: [mod, 'A'], label: 'Select all' },
+        { keys: [mod, shift, 'A'], label: 'Sync all accounts' },
+        { keys: [mod, 'L'], label: 'Load images' },
+      ],
+    },
+  ]
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Content class="max-w-2xl">
+    <Dialog.Header>
+      <Dialog.Title>Keyboard shortcuts</Dialog.Title>
+    </Dialog.Header>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6 max-h-[70vh] overflow-y-auto pr-1 scrollbar-thin">
+      {#each groups as group (group.title)}
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+            {group.title}
+          </h3>
+          <div class="space-y-1.5">
+            {#each group.items as sc (sc.label + sc.keys.join())}
+              <div class="flex items-center justify-between gap-3 text-sm">
+                <span class="text-foreground">{sc.label}</span>
+                <span class="flex items-center gap-1 shrink-0">
+                  {#each sc.keys as key (key)}
+                    <kbd class="min-w-[1.5rem] text-center rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                      {key}
+                    </kbd>
+                  {/each}
+                </span>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </div>
+  </Dialog.Content>
+</Dialog.Root>

--- a/frontend/src/lib/components/list/ConversationRow.svelte
+++ b/frontend/src/lib/components/list/ConversationRow.svelte
@@ -21,6 +21,7 @@
     selectedMessageIds: string[]  // All message IDs from checked conversations (for multi-select)
     selectedIsStarred: boolean    // Aggregated star state for multi-select
     selectedIsRead: boolean       // Aggregated read state for multi-select
+    selectionMode?: boolean       // Show checkbox column only while selecting
     showAccountIndicator?: boolean  // Show account color dot in unified inbox view
     accountColor?: string           // Account color for the indicator
     accountName?: string            // Account name for tooltip
@@ -33,6 +34,7 @@
     onSelect: (e?: MouseEvent) => void
     onCheck: (checked: boolean, event?: MouseEvent) => void
     onClearSelection: () => void  // Clear multi-select when right-clicking unchecked row
+    onSelectMode: () => void      // Enter multi-select from the context menu
     onActionComplete?: (autoSelectNext?: boolean) => void
     onReply?: (mode: 'reply' | 'reply-all' | 'forward', messageId: string) => void
   }
@@ -48,6 +50,7 @@
     selectedMessageIds,
     selectedIsStarred,
     selectedIsRead,
+    selectionMode = false,
     showAccountIndicator = false,
     accountColor = '',
     accountName = '',
@@ -60,6 +63,7 @@
     onSelect,
     onCheck,
     onClearSelection,
+    onSelectMode,
     onActionComplete,
     onReply,
   }: Props = $props()
@@ -155,6 +159,10 @@
     }
   }
 
+  function getSenderEmail(): string {
+    return conversation.participants?.[0]?.email || ''
+  }
+
   function getInitials(conv: message.Conversation): string {
     if (!conv.participants || conv.participants.length === 0) {
       return '?'
@@ -230,6 +238,11 @@
     }
   }
 
+  function handleSelectMode() {
+    onCheck(true)
+    onSelectMode()
+  }
+
   // Computed values for context menu based on selection state
   const contextMenuMessageIds = $derived(useMultiSelect ? selectedMessageIds : ownMessageIds)
   const contextMenuIsStarred = $derived(useMultiSelect ? selectedIsStarred : ownIsStarred)
@@ -256,8 +269,10 @@
   {folderType}
   isStarred={contextMenuIsStarred}
   isRead={contextMenuIsRead}
+  senderEmail={getSenderEmail()}
   {onActionComplete}
   onReply={useMultiSelect ? undefined : onReply}
+  onSelectMode={handleSelectMode}
   onOpenChange={(open: boolean) => { if (open) handleContextMenu() }}
 >
   <div
@@ -272,23 +287,22 @@
     role="button"
     tabindex="0"
   >
-    <!-- Checkbox (visible on hover or when checked) -->
-    <div
-      class="{densityClasses.checkbox[density]} flex-shrink-0 flex items-center justify-center self-center {checked
-        ? 'opacity-100'
-        : 'opacity-0 group-hover:opacity-40 hover:!opacity-100 max-[767px]:opacity-40 max-[767px]:active:opacity-100'} transition-opacity duration-200"
-    >
-      <button
-        class="{densityClasses.checkboxInner[density]} rounded border {checked
-          ? 'bg-primary border-primary'
-          : 'border-muted-foreground hover:border-primary'} flex items-center justify-center transition-colors duration-200"
-        onclick={handleCheckboxClick}
+    {#if selectionMode}
+      <div
+        class="{densityClasses.checkbox[density]} flex-shrink-0 flex items-center justify-center self-center"
       >
-        {#if checked}
-          <Icon icon="mdi:check" class="{densityClasses.checkIcon[density]} text-primary-foreground" />
-        {/if}
-      </button>
-    </div>
+        <button
+          class="{densityClasses.checkboxInner[density]} rounded border {checked
+            ? 'bg-primary border-primary'
+            : 'border-muted-foreground hover:border-primary'} flex items-center justify-center transition-colors duration-200"
+          onclick={handleCheckboxClick}
+        >
+          {#if checked}
+            <Icon icon="mdi:check" class="{densityClasses.checkIcon[density]} text-primary-foreground" />
+          {/if}
+        </button>
+      </div>
+    {/if}
 
     <!-- Sender circle (colored, with initials) -->
     {#if getShowMessageListCircles()}

--- a/frontend/src/lib/components/list/MessageList.svelte
+++ b/frontend/src/lib/components/list/MessageList.svelte
@@ -6,7 +6,7 @@
   import { cn } from '$lib/utils'
   import { Button } from '$lib/components/ui/button'
   // @ts-ignore - wailsjs bindings
-  import { GetConversations, GetConversationCount, SyncFolder, ForceSyncFolder, CancelFolderSync, SetMessageListSortOrder, GetUnifiedInboxConversations, GetUnifiedInboxCount, SearchConversations, SearchUnifiedInbox, GetSearchCount, GetSearchCountUnifiedInbox, GetFTSIndexStatus, IsFTSIndexing, Trash, DeletePermanently, EmptyTrash, Undo, IMAPSearchFolder, FetchServerMessage } from '../../../../wailsjs/go/app/App'
+  import { GetConversations, GetConversationCount, SyncFolder, ForceSyncFolder, CancelFolderSync, SetMessageListSortOrder, GetUnifiedInboxConversations, GetUnifiedInboxCount, SearchConversations, SearchUnifiedInbox, GetSearchCount, GetSearchCountUnifiedInbox, GetFTSIndexStatus, IsFTSIndexing, Trash, DeletePermanently, EmptyTrash, Undo, IMAPSearchFolder, FetchServerMessage, MoveToFolder } from '../../../../wailsjs/go/app/App'
   import { toasts } from '$lib/stores/toast'
   import { _ } from '$lib/i18n'
   import { ConfirmDialog } from '$lib/components/ui/confirm-dialog'
@@ -17,7 +17,9 @@
   import { getMessageListDensity, getMessageListSortOrder, setMessageListSortOrder } from '$lib/stores/settings.svelte'
   import { accountStore } from '$lib/stores/accounts.svelte'
   import { getLayoutMode, hideViewer } from '$lib/stores/layout.svelte'
-  import { isDialogGuardActive } from '$lib/stores/dialogGuard'
+  import { dialogGuardClose, dialogGuardOpen, isDialogGuardActive } from '$lib/stores/dialogGuard'
+  import { learnMoveSuggestion } from '$lib/stores/moveSuggestions'
+  import FolderPickerDialog from '$lib/components/common/FolderPickerDialog.svelte'
 
   interface Props {
     accountId?: string | null
@@ -71,6 +73,21 @@
   // Multi-select state
   let checkedThreadIds = $state<Set<string>>(new Set())
   let lastClickedIndex = $state<number | null>(null)
+  const selectionMode = $derived(checkedThreadIds.size > 0)
+
+  // Keyboard Move To dialog state
+  let showMovePicker = $state(false)
+  let movePickerAccountId = $state('')
+  let movePickerCurrentFolderId = $state('')
+  let movePickerSenderEmail = $state('')
+  let pendingMoveMessageIds = $state<string[]>([])
+
+  $effect(() => {
+    if (showMovePicker) {
+      dialogGuardOpen()
+      return () => dialogGuardClose()
+    }
+  })
 
   // Pagination
   const PAGE_SIZE = 50
@@ -781,6 +798,21 @@
     onConversationSelect?.(threadId, realFolderId, realAccountId)
   }
 
+  function openConversationAtIndex(index: number) {
+    const conversation = activeList[index] as any
+    if (!conversation) return
+
+    const realFolderId = (isUnifiedView || isSearchMode) && conversation.folderId ? conversation.folderId : folderId!
+    const realAccountId = (isUnifiedView || isSearchMode) && conversation.accountId ? conversation.accountId : accountId!
+
+    if (serverSearchMode && conversation._isLocal === false && conversation._uid) {
+      fetchAndSelectServerResult(conversation, realFolderId, realAccountId)
+      return
+    }
+
+    onConversationSelect?.(conversation.threadId, realFolderId, realAccountId)
+  }
+
   // Fetch a non-local server result, save locally, update the result, then select
   async function fetchAndSelectServerResult(conversation: any, realFolderId: string, realAccountId: string) {
     try {
@@ -947,7 +979,7 @@
   }
 
   // Select previous message (exposed for keyboard navigation)
-  // Just moves focus, doesn't clear checkboxes or open in viewer
+  // Moves focus and optionally opens in viewer
   export function selectPrevious() {
     if (activeList.length === 0) return
 
@@ -958,22 +990,28 @@
     if (conv) {
       selectedThreadId = conv.threadId
       scrollToIndex(newIndex)
+      openConversationAtIndex(newIndex)
       // Blur any focused element so Enter key triggers openSelected() instead of the button
       ;(document.activeElement as HTMLElement)?.blur?.()
     }
   }
 
   // Select next message (exposed for keyboard navigation)
-  // Just moves focus, doesn't clear checkboxes or open in viewer
-  export function selectNext() {
+  // Moves focus and opens in viewer
+  export async function selectNext() {
     if (activeList.length === 0) return
 
     const currentIndex = getSelectedIndex()
 
-    // If at last message and more are available, focus the "Load more" button
+    // If at the page boundary, load the next page and keep arrow navigation
+    // moving through conversations instead of sending focus to the button.
     if (currentIndex >= activeList.length - 1 && activeList.length < activeCount) {
-      loadMoreButtonRef?.focus()
-      return
+      if (isSearchMode) {
+        await loadMoreSearchResults()
+      } else {
+        offset += PAGE_SIZE
+        await loadConversations()
+      }
     }
 
     const newIndex = currentIndex >= activeList.length - 1 ? activeList.length - 1 : currentIndex + 1
@@ -982,6 +1020,7 @@
     if (conv) {
       selectedThreadId = conv.threadId
       scrollToIndex(newIndex)
+      openConversationAtIndex(newIndex)
       // Blur any focused element so Enter key triggers openSelected() instead of the button
       ;(document.activeElement as HTMLElement)?.blur?.()
     }
@@ -993,10 +1032,7 @@
 
     const index = getSelectedIndex()
     if (index >= 0) {
-      const conv = activeList[index] as any
-      const realFolderId = (isUnifiedView || isSearchMode) && conv.folderId ? conv.folderId : folderId!
-      const realAccountId = (isUnifiedView || isSearchMode) && conv.accountId ? conv.accountId : accountId!
-      onConversationSelect?.(selectedThreadId, realFolderId, realAccountId)
+      openConversationAtIndex(index)
     }
   }
 
@@ -1056,6 +1092,52 @@
     if (!selectedThreadId) return false
     const conv = activeList.find(c => c.threadId === selectedThreadId) as any
     return conv?.isStarred ?? false
+  }
+
+  export function isSelectedRead(): boolean {
+    if (!selectedThreadId) return true
+    const conv = activeList.find(c => c.threadId === selectedThreadId) as any
+    return (conv?.unreadCount || 0) === 0
+  }
+
+  function getConversationSenderEmail(conv: any): string {
+    return conv?.participants?.[0]?.email || ''
+  }
+
+  export function openMoveTo() {
+    const messageIds = hasCheckedMessages() ? getCheckedMessageIds() : getSelectedMessageIds()
+    if (messageIds.length === 0) return
+
+    const index = getSelectedIndex()
+    const conv = index >= 0 ? activeList[index] as any : null
+    const info = getSelectedConversationInfo()
+    const targetAccountId = info?.accountId || accountId
+    const targetFolderId = info?.folderId || folderId
+    if (!targetAccountId || !targetFolderId || targetAccountId === 'unified') return
+
+    pendingMoveMessageIds = messageIds
+    movePickerAccountId = targetAccountId
+    movePickerCurrentFolderId = targetFolderId
+    movePickerSenderEmail = getConversationSenderEmail(conv)
+    showMovePicker = true
+  }
+
+  async function handleMovePickerSelect(destFolderId: string, folderName: string, destAccountId: string, folderPath?: string) {
+    showMovePicker = false
+    if (pendingMoveMessageIds.length === 0) return
+    try {
+      learnMoveSuggestion(movePickerSenderEmail, { accountId: destAccountId, folderId: destFolderId, folderName, folderPath })
+      await MoveToFolder(pendingMoveMessageIds, destFolderId)
+      toasts.success($_('toast.movedTo', { values: { folder: folderName } }), [{ label: $_('common.undo'), onClick: handleUndo }])
+      clearChecked()
+      handleActionComplete(true)
+    } catch (err) {
+      console.error('Move failed:', err)
+      toasts.error($_('toast.failedToMove'))
+    } finally {
+      pendingMoveMessageIds = []
+      movePickerSenderEmail = ''
+    }
   }
 
   // Toggle checkbox for focused message (Space key)
@@ -1535,10 +1617,12 @@
               {selectedMessageIds}
               selectedIsStarred={!selectedHasUnstarred}
               selectedIsRead={!selectedHasUnread}
+              {selectionMode}
               isNonLocal={result._isLocal === false}
               onSelect={(e) => selectConversation(result.threadId, index, e)}
               onCheck={(checked, e) => handleCheck(result.threadId, checked, index, e)}
               onClearSelection={clearSelection}
+              onSelectMode={() => {}}
               onActionComplete={handleActionComplete}
               {onReply}
             />
@@ -1603,6 +1687,7 @@
             {selectedMessageIds}
             selectedIsStarred={!selectedHasUnstarred}
             selectedIsRead={!selectedHasUnread}
+            {selectionMode}
             showAccountIndicator={isUnifiedView}
             accountColor={resultAccountColor}
             accountName={resultAccountName}
@@ -1614,6 +1699,7 @@
             onSelect={(e) => selectConversation(result.threadId, index, e)}
             onCheck={(checked, e) => handleCheck(result.threadId, checked, index, e)}
             onClearSelection={clearSelection}
+            onSelectMode={() => {}}
             onActionComplete={handleActionComplete}
             {onReply}
           />
@@ -1673,12 +1759,14 @@
           {selectedMessageIds}
           selectedIsStarred={!selectedHasUnstarred}
           selectedIsRead={!selectedHasUnread}
+          {selectionMode}
           showAccountIndicator={isUnifiedView}
           accountColor={convAccountColor}
           accountName={convAccountName}
           onSelect={(e) => selectConversation(conv.threadId, index, e)}
           onCheck={(checked, e) => handleCheck(conv.threadId, checked, index, e)}
           onClearSelection={clearSelection}
+          onSelectMode={() => {}}
           onActionComplete={handleActionComplete}
           {onReply}
         />
@@ -1703,6 +1791,16 @@
     {/if}
   </div>
 </div>
+
+<FolderPickerDialog
+  bind:open={showMovePicker}
+  title={$_('contextMenu.moveTo')}
+  initialAccountId={movePickerAccountId}
+  accounts={accountStore.accounts.map((acc) => acc.account)}
+  excludeFolderId={movePickerCurrentFolderId}
+  senderEmail={movePickerSenderEmail}
+  onSelect={handleMovePickerSelect}
+/>
 
 <!-- Permanent Delete Confirmation Dialog -->
 <ConfirmDialog

--- a/frontend/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/frontend/src/lib/components/ui/dialog/dialog-content.svelte
@@ -9,6 +9,8 @@
     class?: string
     overlayClass?: string
     showOverlay?: boolean
+    /** Show the top-right close (X) button */
+    showClose?: boolean
     children?: Snippet
     /** Prevent focus from returning to trigger element on close */
     preventCloseAutoFocus?: boolean
@@ -21,6 +23,7 @@
     class: className,
     overlayClass = '',
     showOverlay = true,
+    showClose = true,
     children,
     preventCloseAutoFocus = false,
     onInteractOutside,
@@ -49,12 +52,14 @@
       {#if children}
         {@render children()}
       {/if}
-      <DialogPrimitive.Close
-        class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
-      >
-        <Icon icon="mdi:close" class="h-4 w-4" />
-        <span class="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {#if showClose}
+        <DialogPrimitive.Close
+          class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+        >
+          <Icon icon="feather:x" class="h-4 w-4" />
+          <span class="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      {/if}
     </DialogPrimitive.Content>
   </div>
 </DialogPrimitive.Portal>

--- a/frontend/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/frontend/src/lib/components/ui/dialog/dialog-content.svelte
@@ -7,6 +7,8 @@
 
   interface Props {
     class?: string
+    overlayClass?: string
+    showOverlay?: boolean
     children?: Snippet
     /** Prevent focus from returning to trigger element on close */
     preventCloseAutoFocus?: boolean
@@ -15,7 +17,14 @@
     onInteractOutside?: (e: Event) => void
   }
 
-  let { class: className, children, preventCloseAutoFocus = false, onInteractOutside }: Props = $props()
+  let {
+    class: className,
+    overlayClass = '',
+    showOverlay = true,
+    children,
+    preventCloseAutoFocus = false,
+    onInteractOutside,
+  }: Props = $props()
 
   function handleCloseAutoFocus(e: Event) {
     if (preventCloseAutoFocus) {
@@ -25,7 +34,9 @@
 </script>
 
 <DialogPrimitive.Portal>
-  <DialogOverlay />
+  {#if showOverlay}
+    <DialogOverlay class={overlayClass} />
+  {/if}
   <div class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
     <DialogPrimitive.Content
       onCloseAutoFocus={handleCloseAutoFocus}

--- a/frontend/src/lib/i18n/locales/cs.json
+++ b/frontend/src/lib/i18n/locales/cs.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "Označit jako NENÍ spam",
     "moveTo": "Přesunout do",
     "copyTo": "Kopírovat do",
+    "select": "Vybrat",
     "star": "Označit hvězdičkou",
     "removeStar": "Odebrat hvězdičku",
     "markAsRead": "Označit jako přečtené",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Označit vše jako nepřečtené",
     "noFoldersAvailable": "Žádné dostupné složky",
     "searchFolders": "Hledat složky...",
+    "suggested": "Navrženo",
     "account": "Účet"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "Als kein Spam markieren",
     "moveTo": "Verschieben nach",
     "copyTo": "Kopieren nach",
+    "select": "Auswählen",
     "star": "Markieren",
     "removeStar": "Markierung entfernen",
     "markAsRead": "Als gelesen markieren",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Alle als ungelesen markieren",
     "noFoldersAvailable": "Keine Ordner verfügbar",
     "searchFolders": "Ordner suchen...",
+    "suggested": "Vorgeschlagen",
     "account": "Konto"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "Mark as NOT Spam",
     "moveTo": "Move to",
     "copyTo": "Copy to",
+    "select": "Select",
     "star": "Star",
     "removeStar": "Remove Star",
     "markAsRead": "Mark as Read",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Mark All as Unread",
     "noFoldersAvailable": "No folders available",
     "searchFolders": "Search folders...",
+    "suggested": "Suggested",
     "account": "Account"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -47,6 +47,21 @@
     "loadingFolders": "Loading folders...",
     "noFoldersSynced": "No folders synced"
   },
+  "commandPalette": {
+    "placeholder": "Type a command or search…",
+    "noResults": "No matching commands",
+    "newMessage": "New message",
+    "markRead": "Mark as read",
+    "markUnread": "Mark as unread",
+    "toggleStar": "Star / unstar",
+    "archive": "Archive",
+    "moveTo": "Move to folder…",
+    "markSpam": "Mark as spam",
+    "delete": "Delete",
+    "undo": "Undo last action",
+    "refresh": "Refresh / sync all",
+    "shortcuts": "Keyboard shortcuts"
+  },
   "messageList": {
     "searchMessages": "Search messages...",
     "noMessages": "No messages in this folder",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "N'est pas un Spam",
     "moveTo": "Déplacer vers",
     "copyTo": "Copier vers",
+    "select": "Sélectionner",
     "star": "Suivre",
     "removeStar": "Ne plus suivre",
     "markAsRead": "Marquer comme lu",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Tout marquer comme non lu",
     "noFoldersAvailable": "Aucun dossier disponible",
     "searchFolders": "Rechercher des dossiers...",
+    "suggested": "Suggéré",
     "account": "Compte"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/it.json
+++ b/frontend/src/lib/i18n/locales/it.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "Segna come NON spam",
     "moveTo": "Sposta in",
     "copyTo": "Copia in",
+    "select": "Seleziona",
     "star": "Aggiungi ai preferiti",
     "removeStar": "Rimuovi dai preferiti",
     "markAsRead": "Segna come letta",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Segna tutte come NON lette",
     "noFoldersAvailable": "Cartelle non disponibili",
     "searchFolders": "Cerca cartelle...",
+    "suggested": "Suggerito",
     "account": "Account"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/nb.json
+++ b/frontend/src/lib/i18n/locales/nb.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "Fjern merking som søppelpost",
     "moveTo": "Flytt til",
     "copyTo": "Kopiér til",
+    "select": "Velg",
     "star": "Stjernemerk",
     "removeStar": "Fjern stjernemerking",
     "markAsRead": "Merk som lest",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "Merk alle som ulest",
     "noFoldersAvailable": "Ingen mapper tilgjengelige",
     "searchFolders": "Søk i mapper…",
+    "suggested": "Foreslått",
     "account": "Konto"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/zh-CN.json
+++ b/frontend/src/lib/i18n/locales/zh-CN.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "标记为非垃圾邮件",
     "moveTo": "移动到",
     "copyTo": "复制到",
+    "select": "选择",
     "star": "加星标",
     "removeStar": "移除星标",
     "markAsRead": "标记为已读",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "全部标记为未读",
     "noFoldersAvailable": "没有可用的文件夹",
     "searchFolders": "搜索文件夹...",
+    "suggested": "建议",
     "account": "账号"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/zh-HK.json
+++ b/frontend/src/lib/i18n/locales/zh-HK.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "標記為非垃圾郵件",
     "moveTo": "移動至",
     "copyTo": "複製至",
+    "select": "選取",
     "star": "加星號",
     "removeStar": "移除星號",
     "markAsRead": "標記為已讀",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "全部標記為未讀",
     "noFoldersAvailable": "沒有可用的資料夾",
     "searchFolders": "搜尋資料夾...",
+    "suggested": "建議",
     "account": "帳戶"
   },
   "toast": {

--- a/frontend/src/lib/i18n/locales/zh-TW.json
+++ b/frontend/src/lib/i18n/locales/zh-TW.json
@@ -243,6 +243,7 @@
     "markAsNotSpam": "標記為非垃圾郵件",
     "moveTo": "移動至",
     "copyTo": "複製至",
+    "select": "選取",
     "star": "加星號",
     "removeStar": "移除星號",
     "markAsRead": "標記為已讀",
@@ -251,6 +252,7 @@
     "markAllAsUnread": "全部標記為未讀",
     "noFoldersAvailable": "沒有可用的資料夾",
     "searchFolders": "搜尋資料夾...",
+    "suggested": "建議",
     "account": "帳號"
   },
   "toast": {

--- a/frontend/src/lib/stores/moveSuggestions.ts
+++ b/frontend/src/lib/stores/moveSuggestions.ts
@@ -1,0 +1,159 @@
+import type { folder } from '../../../wailsjs/go/models'
+
+const STORAGE_KEY = 'aerion.moveSuggestions.v1'
+const MAX_BUCKET_ENTRIES = 80
+
+type SuggestionBucket = Record<string, StoredTarget>
+
+interface StoredTarget {
+  accountId: string
+  folderId: string
+  folderName: string
+  folderPath?: string
+  count: number
+  lastUsed: number
+}
+
+interface SuggestionStore {
+  bySender: Record<string, SuggestionBucket>
+  byDomain: Record<string, SuggestionBucket>
+}
+
+export interface MoveSuggestion {
+  accountId: string
+  folderId: string
+  folderName: string
+  folderPath?: string
+  exactCount: number
+  domainCount: number
+  lastUsed: number
+}
+
+function emptyStore(): SuggestionStore {
+  return { bySender: {}, byDomain: {} }
+}
+
+function normalizeEmail(email: string | null | undefined): string {
+  return (email || '').trim().toLowerCase()
+}
+
+function getDomain(email: string): string {
+  const at = email.lastIndexOf('@')
+  return at > -1 ? email.slice(at + 1) : ''
+}
+
+function targetKey(accountId: string, folderId: string): string {
+  return `${accountId}:${folderId}`
+}
+
+function readStore(): SuggestionStore {
+  if (typeof localStorage === 'undefined') return emptyStore()
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return emptyStore()
+    const parsed = JSON.parse(raw) as Partial<SuggestionStore>
+    return {
+      bySender: parsed.bySender || {},
+      byDomain: parsed.byDomain || {},
+    }
+  } catch {
+    return emptyStore()
+  }
+}
+
+function writeStore(store: SuggestionStore) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(store))
+}
+
+function trimBucket(bucket: SuggestionBucket) {
+  const entries = Object.entries(bucket)
+  if (entries.length <= MAX_BUCKET_ENTRIES) return
+  entries
+    .sort(([, a], [, b]) => b.lastUsed - a.lastUsed)
+    .slice(MAX_BUCKET_ENTRIES)
+    .forEach(([key]) => delete bucket[key])
+}
+
+function incrementBucket(
+  buckets: Record<string, SuggestionBucket>,
+  bucketKey: string,
+  target: Omit<StoredTarget, 'count' | 'lastUsed'>,
+) {
+  if (!bucketKey) return
+  const bucket = buckets[bucketKey] || {}
+  const key = targetKey(target.accountId, target.folderId)
+  const existing = bucket[key]
+  bucket[key] = {
+    ...target,
+    count: (existing?.count || 0) + 1,
+    lastUsed: Date.now(),
+  }
+  trimBucket(bucket)
+  buckets[bucketKey] = bucket
+}
+
+export function learnMoveSuggestion(
+  senderEmail: string | null | undefined,
+  target: { accountId: string; folderId: string; folderName: string; folderPath?: string },
+) {
+  const email = normalizeEmail(senderEmail)
+  if (!email || !target.accountId || !target.folderId) return
+
+  const store = readStore()
+  const storedTarget = {
+    accountId: target.accountId,
+    folderId: target.folderId,
+    folderName: target.folderName,
+    folderPath: target.folderPath,
+  }
+
+  incrementBucket(store.bySender, email, storedTarget)
+  incrementBucket(store.byDomain, getDomain(email), storedTarget)
+  writeStore(store)
+}
+
+export function getMoveSuggestions(
+  senderEmail: string | null | undefined,
+  availableFolders: folder.Folder[],
+  selectedAccountId: string,
+  limit = 4,
+): MoveSuggestion[] {
+  const email = normalizeEmail(senderEmail)
+  if (!email || availableFolders.length === 0) return []
+
+  const store = readStore()
+  const domain = getDomain(email)
+  const senderBucket = store.bySender[email] || {}
+  const domainBucket = store.byDomain[domain] || {}
+  const available = new Map(
+    availableFolders.map((f) => [targetKey(selectedAccountId, f.id), f])
+  )
+  const keys = new Set([...Object.keys(senderBucket), ...Object.keys(domainBucket)])
+
+  return [...keys]
+    .filter((key) => available.has(key))
+    .map((key) => {
+      const folderInfo = available.get(key)!
+      const exact = senderBucket[key]
+      const domainMatch = domainBucket[key]
+      return {
+        accountId: selectedAccountId,
+        folderId: folderInfo.id,
+        folderName: folderInfo.name,
+        folderPath: folderInfo.path,
+        exactCount: exact?.count || 0,
+        domainCount: domainMatch?.count || 0,
+        lastUsed: Math.max(exact?.lastUsed || 0, domainMatch?.lastUsed || 0),
+      }
+    })
+    .sort((a, b) => {
+      const aSpecificity = a.exactCount > 0 ? 1 : 0
+      const bSpecificity = b.exactCount > 0 ? 1 : 0
+      if (aSpecificity !== bSpecificity) return bSpecificity - aSpecificity
+      if (a.exactCount !== b.exactCount) return b.exactCount - a.exactCount
+      if (a.domainCount !== b.domainCount) return b.domainCount - a.domainCount
+      return b.lastUsed - a.lastUsed
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
## What

Adds a **command palette** (Cmd/Ctrl+Shift+P) for fast, searchable access to message actions — compose, mark read/unread, star/unstar, archive, move-to-folder, mark spam, delete, undo, refresh — plus a **keyboard-shortcuts reference dialog**.

- New: `CommandPalette.svelte`, `ShortcutsDialog.svelte`
- `App.svelte`: palette state, command list, open shortcut (Cmd/Ctrl+Shift+P, chosen because Cmd+K is already Archive)
- `dialog-content` gains a `showClose` prop used by the palette
- `en.json`: `commandPalette.*` strings

## Closes

Closes #245

## ⚠️ Depends on #250

This branch is **stacked on #250** (move-to suggestions + selection mode) — the palette's "Move to folder" command uses `messageListRef.openMoveTo()` introduced there. Until #250 merges, this PR's diff includes those commits too. **I'll rebase this onto `main` once #250 lands** so the diff narrows to just the palette. (If you'd rather I squash both into one PR, happy to.)

## Notes (transparency)

- This work is **AI-assisted**.
- Un-bundled from a larger local branch built on the **v0.2.5 base**; targeted at **`main`** (applies cleanly). Happy to retarget to `v0.3.0-dev` — note its keyboard refactor will need integration there.
- Verified locally: `eslint` clean, `svelte-check` 0 errors/0 warnings, `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
