### PR TITLE
feat: background send with configurable unsend (undo-send) timer

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -39,6 +39,16 @@ func (a *App) SetMarkAsReadDelay(delayMs int) error {
 	return a.settingsStore.SetMarkAsReadDelay(delayMs)
 }
 
+// GetUnsendTimer returns the undo-send window in seconds (0 = immediate)
+func (a *App) GetUnsendTimer() (int, error) {
+	return a.settingsStore.GetUnsendTimer()
+}
+
+// SetUnsendTimer sets the undo-send window in seconds (0, 5, 10, or 30)
+func (a *App) SetUnsendTimer(seconds int) error {
+	return a.settingsStore.SetUnsendTimer(seconds)
+}
+
 // GetMessageListDensity returns the message list density setting
 func (a *App) GetMessageListDensity() (string, error) {
 	return a.settingsStore.GetMessageListDensity()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,8 +13,9 @@
   import CertificateDialog from './lib/components/settings/CertificateDialog.svelte'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import { accountStore } from '$lib/stores/accounts.svelte'
-  import { addToast } from '$lib/stores/toast'
-  import { loadSettings, getThemeMode, getShowTitleBar, getNativeTitleBar, getComposerMode, getMailtoMode } from '$lib/stores/settings.svelte'
+  import { addToast, toasts } from '$lib/stores/toast'
+  import { sendStarted, sendFinished } from '$lib/stores/outbox.svelte'
+  import { loadSettings, getThemeMode, getShowTitleBar, getNativeTitleBar, getComposerMode, getMailtoMode, getUnsendTimer } from '$lib/stores/settings.svelte'
   import { loadImageAllowlist } from '$lib/stores/imageAllowlist.svelte'
   import { initTheme, applyThemeFromMode, handleSystemThemeEvent, handleMediaQueryChange } from '$lib/stores/theme.svelte'
   import { loadUIState, saveUIState, paneConstraints } from '$lib/stores/uiState.svelte'
@@ -31,7 +32,7 @@
   import { isDialogGuardActive } from '$lib/stores/dialogGuard'
   import { initLayout, getLayoutMode, getResponsiveView, showViewer, hideViewer, showSidebar, hideSidebar, isResponsive } from '$lib/stores/layout.svelte'
   // @ts-ignore - wailsjs path
-  import { PrepareReply, GetPendingMailto, GetDraft, MarkAsRead, MarkAsUnread, Star, Unstar, Archive, MarkAsSpam, MarkAsNotSpam, Undo, GetTermsAccepted, SetTermsAccepted, RefreshWindowConstraints, AcceptCertificate, GetStartHiddenActive, CloseWindow, QuitApp, OpenComposerWindow, GetSystemTheme, NotifyStartupComplete } from '../wailsjs/go/app/App.js'
+  import { PrepareReply, GetPendingMailto, GetDraft, MarkAsRead, MarkAsUnread, Star, Unstar, Archive, MarkAsSpam, MarkAsNotSpam, Undo, GetTermsAccepted, SetTermsAccepted, RefreshWindowConstraints, AcceptCertificate, GetStartHiddenActive, CloseWindow, QuitApp, OpenComposerWindow, GetSystemTheme, NotifyStartupComplete, SendMessage, DeleteDraft } from '../wailsjs/go/app/App.js'
   // @ts-ignore - wailsjs path
   import { smtp, folder, certificate } from '../wailsjs/go/models'
   // @ts-ignore - wailsjs runtime
@@ -644,6 +645,87 @@
     showComposer = false
     composerAccountId = null
     composerInitialMessage = null
+  }
+
+  // --- Deferred (undo-able, background) send ---------------------------------
+  // The inline composer hands the built message here on Send, then closes. We
+  // show a "Sending… (Undo)" toast counting down the unsend window; when it
+  // elapses we perform the real network send in the background so the user can
+  // keep working.
+  let pendingSendCancel: (() => void) | null = null
+
+  function reopenComposerWith(accountId: string, message: smtp.ComposeMessage) {
+    composerAccountId = accountId
+    composerInitialMessage = message
+    composerDraftId = null
+    composerImagesLoaded = true
+    showComposer = true
+  }
+
+  async function finalizeSend(accountId: string, message: smtp.ComposeMessage, draftId: string | null) {
+    try {
+      await SendMessage(accountId, message)
+      if (draftId) DeleteDraft(draftId).catch((e) => console.error('Failed to delete draft after send:', e))
+      addToast({ type: 'success', message: $_('composer.messageSent') })
+    } catch (err) {
+      console.error('Failed to send message:', err)
+      addToast({ type: 'error', message: $_('composer.failedToSend') })
+      // Don't lose the user's message — reopen it so they can retry.
+      if (draftId) { void handleEditDraft(draftId) } else { reopenComposerWith(accountId, message) }
+    } finally {
+      sendFinished()
+    }
+  }
+
+  function handleQueueSend(payload: { accountId: string; message: smtp.ComposeMessage; draftId: string | null }) {
+    const { accountId, message, draftId } = payload
+    const delay = getUnsendTimer()
+    sendStarted()
+
+    // Immediate mode: still send in the background (non-blocking), no undo window.
+    if (delay <= 0) {
+      void finalizeSend(accountId, message, draftId)
+      return
+    }
+
+    let remaining = delay
+    let timer: ReturnType<typeof setInterval> | null = null
+    let done = false
+
+    const cleanup = () => {
+      if (timer) { clearInterval(timer); timer = null }
+      if (pendingSendCancel === cancel) pendingSendCancel = null
+    }
+    const cancel = () => {
+      if (done) return
+      done = true
+      cleanup()
+      toasts.remove(toastId)
+      sendFinished()
+      // Reopen so the user can keep editing / discard.
+      if (draftId) { void handleEditDraft(draftId) } else { reopenComposerWith(accountId, message) }
+      addToast({ type: 'info', message: $_('composer.sendCanceled') })
+    }
+    const fire = () => {
+      if (done) return
+      done = true
+      cleanup()
+      toasts.remove(toastId)
+      void finalizeSend(accountId, message, draftId)
+    }
+
+    const toastId = addToast({
+      type: 'info',
+      message: $_('composer.sendingIn', { values: { seconds: remaining } }),
+      duration: delay * 1000 + 1500,
+      actions: [{ label: $_('common.undo'), onClick: cancel }],
+    })
+    pendingSendCancel = cancel
+    timer = setInterval(() => {
+      remaining -= 1
+      if (remaining <= 0) { fire(); return }
+      toasts.update(toastId, { message: $_('composer.sendingIn', { values: { seconds: remaining } }) })
+    }, 1000)
   }
 
   // Pane sizing state
@@ -1380,6 +1462,7 @@
         imagesLoaded={composerImagesLoaded}
         onClose={closeComposer}
         onSent={closeComposer}
+        onQueueSend={handleQueueSend}
       />
     </div>
   </div>

--- a/frontend/src/lib/components/composer/Composer.svelte
+++ b/frontend/src/lib/components/composer/Composer.svelte
@@ -78,9 +78,13 @@
     onTitleChange?: (to: string, subject: string) => void
     /** Whether remote images were loaded in the viewer before reply/forward */
     imagesLoaded?: boolean
+    /** Deferred-send hand-off (inline composer): host performs the actual network
+     *  send after the undo window so the user can keep working. When provided and
+     *  not detached, Send closes immediately and the host owns sending. */
+    onQueueSend?: (payload: { accountId: string; message: smtp.ComposeMessage; draftId: string | null }) => void
   }
 
-  let { accountId, initialMessage = null, draftId = null, messageId = null, onClose, onSent, api: propApi, isDetached = false, closeRequested = false, onCloseHandled, onTitleChange, imagesLoaded = false }: Props = $props()
+  let { accountId, initialMessage = null, draftId = null, messageId = null, onClose, onSent, api: propApi, isDetached = false, closeRequested = false, onCloseHandled, onTitleChange, imagesLoaded = false, onQueueSend }: Props = $props()
 
   // Get API from context, props, or create default main window API
   const contextApi = getContext<ComposerApi | undefined>(COMPOSER_API_KEY)
@@ -1130,6 +1134,16 @@
 
     // Wait for any in-flight draft save to complete before sending
     await savingComplete
+
+    // Deferred send (inline composer): hand the built message to the host, which
+    // performs the actual network send after the undo window. Close immediately so
+    // the user can keep working. The host owns the draft cleanup + "sent" toast.
+    if (onQueueSend && !isDetached) {
+      const queued = buildMessage()
+      onQueueSend({ accountId: activeAccountId, message: queued, draftId: currentDraftId })
+      onClose?.()
+      return
+    }
 
     sending = true
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -184,6 +184,8 @@
     "discardDraft": "Discard",
     "keepEditing": "Keep Editing",
     "messageSent": "Message sent",
+    "sendingIn": "Sending… {seconds}s",
+    "sendCanceled": "Sending canceled",
     "failedToSend": "Failed to send.",
     "noRecipients": "Please add at least one recipient",
     "failedToLoadDraft": "Failed to load draft",

--- a/frontend/src/lib/stores/outbox.svelte.ts
+++ b/frontend/src/lib/stores/outbox.svelte.ts
@@ -1,0 +1,21 @@
+// Outbox state — tracks messages currently being sent (or queued in the undo
+// window) so the UI can show a non-blocking "sending" indicator while the user
+// keeps working. The actual send orchestration (undo timer, network send) lives
+// in App.svelte; this store just exposes the reactive count.
+
+let activeSends = $state(0)
+
+/** True while one or more messages are queued or in-flight. */
+export function getIsSending(): boolean {
+  return activeSends > 0
+}
+
+/** Mark a send as started (queued in the undo window or in-flight). */
+export function sendStarted(): void {
+  activeSends++
+}
+
+/** Mark a send as finished (sent, canceled, or failed). */
+export function sendFinished(): void {
+  activeSends = Math.max(0, activeSends - 1)
+}

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -2,7 +2,7 @@
 // Provides reactive state for application settings
 
 // @ts-ignore - wailsjs path
-import { GetMessageListDensity, GetMessageListSortOrder, GetThemeMode, GetShowTitleBar, GetRunBackground, GetStartHidden, GetAutostart, GetLanguage, GetComposerMode, GetMailtoMode, GetComposerFormat, GetNativeTitleBar, GetAlwaysLoadImages, GetDarkMailContent, GetAccentBarUnread, GetShowMessageListCircles, GetShowViewerCircles } from '../../../wailsjs/go/app/App'
+import { GetMessageListDensity, GetMessageListSortOrder, GetThemeMode, GetShowTitleBar, GetRunBackground, GetStartHidden, GetAutostart, GetLanguage, GetComposerMode, GetMailtoMode, GetComposerFormat, GetNativeTitleBar, GetAlwaysLoadImages, GetDarkMailContent, GetAccentBarUnread, GetShowMessageListCircles, GetShowViewerCircles, GetUnsendTimer } from '../../../wailsjs/go/app/App'
 import { setLocale as setI18nLocale } from '$lib/i18n'
 import { loadDateFnsLocale, getDateFnsLocale } from '$lib/i18n/dateFnsLocale'
 import type { Locale } from 'date-fns'
@@ -40,6 +40,7 @@ let darkMailContent = $state<boolean>(false)
 let accentBarUnread = $state<boolean>(false)
 let showMessageListCircles = $state<boolean>(true)
 let showViewerCircles = $state<boolean>(true)
+let unsendTimer = $state<number>(5) // undo-send window in seconds; 0 = send immediately
 
 // Getter functions to access the state
 export function getMessageListDensity(): MessageListDensity {
@@ -108,6 +109,10 @@ export function getShowMessageListCircles(): boolean {
 
 export function getShowViewerCircles(): boolean {
   return showViewerCircles
+}
+
+export function getUnsendTimer(): number {
+  return unsendTimer
 }
 
 export function getCurrentDateFnsLocale(): Locale | undefined {
@@ -190,7 +195,7 @@ export function setShowViewerCircles(v: boolean) {
 // Load settings from backend (call on app startup)
 export async function loadSettings(): Promise<ThemeMode> {
   try {
-    const [density, sortOrder, theme, titleBar, runBg, startHid, autoSt, lang, compMode, mailMode, compFormat, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles] = await Promise.all([
+    const [density, sortOrder, theme, titleBar, runBg, startHid, autoSt, lang, compMode, mailMode, compFormat, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles, unsendTimerVal] = await Promise.all([
       GetMessageListDensity(),
       GetMessageListSortOrder(),
       GetThemeMode(),
@@ -208,6 +213,7 @@ export async function loadSettings(): Promise<ThemeMode> {
       GetAccentBarUnread(),
       GetShowMessageListCircles(),
       GetShowViewerCircles(),
+      GetUnsendTimer(),
     ])
     messageListDensity = (density as MessageListDensity) || 'standard'
     messageListSortOrder = (sortOrder as MessageListSortOrder) || 'newest'
@@ -225,6 +231,7 @@ export async function loadSettings(): Promise<ThemeMode> {
     accentBarUnread = accentBar ?? false
     showMessageListCircles = listCircles ?? true
     showViewerCircles = viewerCircles ?? true
+    unsendTimer = unsendTimerVal ?? 5
     // Apply saved language (if set, overrides system detection from initI18n)
     if (lang) {
       language = lang

--- a/frontend/src/lib/stores/toast.ts
+++ b/frontend/src/lib/stores/toast.ts
@@ -35,6 +35,11 @@ function createToastStore() {
     update(toasts => toasts.filter(t => t.id !== id))
   }
 
+  // Patch fields of an existing toast (e.g. live countdown text). No-op if gone.
+  function updateToast(id: string, partial: Partial<Omit<Toast, 'id'>>) {
+    update(toasts => toasts.map(t => (t.id === id ? { ...t, ...partial } : t)))
+  }
+
   function success(message: string, actions?: ToastAction[]) {
     return add({ message, type: 'success', actions })
   }
@@ -55,6 +60,7 @@ function createToastStore() {
     subscribe,
     add,
     remove,
+    update: updateToast,
     success,
     error,
     info,

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -179,6 +179,10 @@ export function GetMailtoMode():Promise<string>;
 
 export function GetMarkAsReadDelay():Promise<number>;
 
+export function GetUnsendTimer():Promise<number>;
+
+export function SetUnsendTimer(arg1:number):Promise<void>;
+
 export function GetMessage(arg1:string):Promise<message.Message>;
 
 export function GetMessageCount(arg1:string,arg2:string):Promise<number>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -326,6 +326,14 @@ export function GetMarkAsReadDelay() {
   return window['go']['app']['App']['GetMarkAsReadDelay']();
 }
 
+export function GetUnsendTimer() {
+  return window['go']['app']['App']['GetUnsendTimer']();
+}
+
+export function SetUnsendTimer(arg1) {
+  return window['go']['app']['App']['SetUnsendTimer'](arg1);
+}
+
 export function GetMessage(arg1) {
   return window['go']['app']['App']['GetMessage'](arg1);
 }

--- a/internal/settings/store.go
+++ b/internal/settings/store.go
@@ -16,6 +16,7 @@ import (
 const (
 	KeyReadReceiptResponsePolicy = "read_receipt_response_policy"
 	KeyMarkAsReadDelay           = "mark_as_read_delay"
+	KeyUnsendTimer               = "unsend_timer"
 	KeyMessageListDensity        = "message_list_density"
 	KeyMessageListSortOrder      = "message_list_sort_order"
 	KeyThemeMode                 = "theme_mode"
@@ -119,6 +120,8 @@ const (
 
 // Default mark as read delay in milliseconds (1 second)
 const DefaultMarkAsReadDelay = 1000
+
+const DefaultUnsendTimer = 5
 
 // Store provides settings persistence operations
 type Store struct {
@@ -580,4 +583,30 @@ func ReadNativeTitleBar(dbPath string) bool {
 		return false
 	}
 	return value == "true"
+}
+
+// GetUnsendTimer returns the undo-send window in seconds (0 = immediate, no undo).
+func (s *Store) GetUnsendTimer() (int, error) {
+	value, err := s.Get(KeyUnsendTimer)
+	if err != nil {
+		return DefaultUnsendTimer, err
+	}
+	if value == "" {
+		return DefaultUnsendTimer, nil
+	}
+	secs, err := strconv.Atoi(value)
+	if err != nil {
+		return DefaultUnsendTimer, nil
+	}
+	return secs, nil
+}
+
+// SetUnsendTimer sets the undo-send window in seconds. Valid: 0, 5, 10, 30.
+func (s *Store) SetUnsendTimer(seconds int) error {
+	switch seconds {
+	case 0, 5, 10, 30:
+		return s.Set(KeyUnsendTimer, strconv.Itoa(seconds))
+	default:
+		return fmt.Errorf("invalid unsend timer: %d (must be 0, 5, 10, or 30)", seconds)
+	}
 }


### PR DESCRIPTION
## What

Implements **background send with a configurable unsend (undo-send) timer** (#246).

On Send, the inline composer hands the built message to the host and closes immediately — sending no longer blocks the UI. A **"Sending… (Undo)"** toast counts down the unsend window; when it elapses the real network send runs in the background, so the user can keep working. The **Undo** action cancels and reopens the message.

- New `outbox.svelte.ts` store tracks active sends (for a non-blocking "sending" indicator)
- Configurable window persisted in settings: **0 / 5 / 10 / 30s (default 5)** — `GetUnsendTimer`/`SetUnsendTimer` backend + wails bindings
- `toast` store gains `update()` for the live countdown
- `Composer` gains an `onQueueSend` hand-off; the host owns the actual send + draft cleanup + "sent"/"failed" toast (failures reopen the message so nothing is lost)

## Closes

Closes #246

## Scope note

Backend + orchestration are complete and the window is fully configurable via `SetUnsendTimer` (validated to 0/5/10/30). A **settings-panel selector UI** for the value is **not** included in this PR to keep it focused — happy to add it (or point me at the preferred settings tab and I'll wire it). Default 5s applies out of the box.

## Notes (transparency)

- This work is **AI-assisted**.
- Un-bundled from a larger local branch built on the **v0.2.5 base**; targeted at **`main`** (applies cleanly). Happy to retarget to `v0.3.0-dev`.
- Verified locally: `go build ./...` OK, `go test ./internal/settings/...` passes, `eslint` clean, `svelte-check` 0 errors/0 warnings, `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
