### PR TITLE
feat: open the application log file from Settings → About

### DIFF
--- a/app/log.go
+++ b/app/log.go
@@ -1,6 +1,12 @@
 package app
 
-import "github.com/hkdb/aerion/internal/logging"
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/hkdb/aerion/internal/logging"
+)
 
 // LogFrontend emits a log message from the frontend through the Go-side
 // zerolog logger so frontend diagnostics appear in the same log stream as
@@ -19,6 +25,26 @@ func (a *App) LogFrontend(level, message string) {
 	default:
 		log.Info().Msg(message)
 	}
+}
+
+// OpenLogFile opens the application log file with the OS default handler so the
+// user can inspect sync activity (sync start/complete, fetch counts, errors).
+func (a *App) OpenLogFile() error {
+	if a.paths == nil {
+		return fmt.Errorf("paths not initialized")
+	}
+	path := a.paths.LogPath()
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", path)
+	default:
+		cmd = exec.Command("xdg-open", path)
+	}
+	return cmd.Start()
 }
 
 // LogFrontend mirrors App.LogFrontend for the detached composer process so

--- a/frontend/src/lib/components/settings/AboutTab.svelte
+++ b/frontend/src/lib/components/settings/AboutTab.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
   import Icon from '@iconify/svelte'
   // @ts-ignore - wailsjs path
-  import { GetAppInfo } from '../../../../wailsjs/go/app/App.js'
+  import { GetAppInfo, OpenLogFile } from '../../../../wailsjs/go/app/App.js'
   import { BrowserOpenURL } from '../../../../wailsjs/runtime/runtime'
   import logo from '../../../assets/images/logo-universal.png'
   import { _ } from '$lib/i18n'
@@ -43,6 +43,14 @@
 
   function openTermsOfService() {
     BrowserOpenURL(TERMS_URL)
+  }
+
+  async function openLogFile() {
+    try {
+      await OpenLogFile()
+    } catch (err) {
+      console.error('Failed to open log file:', err)
+    }
   }
 </script>
 
@@ -86,6 +94,13 @@
       >
         <Icon icon="mdi:file-document" class="w-5 h-5" />
         <span>{$_('settingsAbout.termsOfUse')}</span>
+      </button>
+      <button
+        onclick={openLogFile}
+        class="flex items-center gap-2 text-sm text-primary hover:underline transition-colors"
+      >
+        <Icon icon="mdi:file-document-outline" class="w-5 h-5" />
+        <span>{$_('settingsAbout.openLog')}</span>
       </button>
     </div>
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -418,6 +418,7 @@
     "github": "GitHub",
     "privacyPolicy": "Privacy Policy",
     "termsOfUse": "Terms of Use",
+    "openLog": "Open log file",
     "failedToLoad": "Failed to load app information"
   },
   "account": {

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -299,6 +299,8 @@ export function ListSenderCerts():Promise<Array<smime.SenderCert>>;
 
 export function LogFrontend(arg1:string,arg2:string):Promise<void>;
 
+export function OpenLogFile():Promise<void>;
+
 export function LookupHKP(arg1:string):Promise<string>;
 
 export function LookupPGPKey(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -566,6 +566,10 @@ export function LogFrontend(arg1, arg2) {
   return window['go']['app']['App']['LogFrontend'](arg1, arg2);
 }
 
+export function OpenLogFile() {
+  return window['go']['app']['App']['OpenLogFile']();
+}
+
 export function LookupHKP(arg1) {
   return window['go']['app']['App']['LookupHKP'](arg1);
 }

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -140,6 +140,11 @@ func (p *Paths) DatabasePath() string {
 	return filepath.Join(p.Data, "aerion.db")
 }
 
+// LogPath returns the path to the primary application log file.
+func (p *Paths) LogPath() string {
+	return filepath.Join(p.Cache, "aerion.log")
+}
+
 // ContactsDatabasePath returns the path to the contacts database
 func (p *Paths) ContactsDatabasePath() string {
 	return filepath.Join(p.Data, "contacts.db")


### PR DESCRIPTION
## What

Adds an **"Open log file"** button to **Settings → About** that opens the application log with the OS default handler (Closes #249). Lets users inspect sync activity and errors without hunting for the file path.

- `App.OpenLogFile()` — opens `paths.LogPath()` via `open` (macOS) / `start` (Windows) / `xdg-open` (Linux)
- New `Paths.LogPath()` helper (`<cache>/aerion.log`)
- About-tab button + wails binding + `settingsAbout.openLog` string

## Notes (transparency)

- **AI-assisted**. Un-bundled from a larger local branch (v0.2.5 base); targeted at `main` (applies cleanly). Happy to retarget to `v0.3.0-dev`.
- Verified locally: `go build ./...` OK, `eslint` clean, `svelte-check` 0/0, `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
