### PR TITLE
feat: option to toggle account indicators in the unified inbox

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -39,6 +39,16 @@ func (a *App) SetMarkAsReadDelay(delayMs int) error {
 	return a.settingsStore.SetMarkAsReadDelay(delayMs)
 }
 
+// GetShowAccountIndicators returns whether account indicators show in the unified inbox
+func (a *App) GetShowAccountIndicators() (bool, error) {
+	return a.settingsStore.GetShowAccountIndicators()
+}
+
+// SetShowAccountIndicators toggles account indicators in the unified inbox
+func (a *App) SetShowAccountIndicators(enabled bool) error {
+	return a.settingsStore.SetShowAccountIndicators(enabled)
+}
+
 // GetMessageListDensity returns the message list density setting
 func (a *App) GetMessageListDensity() (string, error) {
 	return a.settingsStore.GetMessageListDensity()

--- a/frontend/src/lib/components/list/MessageList.svelte
+++ b/frontend/src/lib/components/list/MessageList.svelte
@@ -14,7 +14,7 @@
   import { message } from '../../../../wailsjs/go/models'
   // @ts-ignore - wailsjs runtime
   import { EventsOn, EventsOff } from '../../../../wailsjs/runtime/runtime'
-  import { getMessageListDensity, getMessageListSortOrder, setMessageListSortOrder } from '$lib/stores/settings.svelte'
+  import { getMessageListDensity, getMessageListSortOrder, setMessageListSortOrder, getShowAccountIndicators } from '$lib/stores/settings.svelte'
   import { accountStore } from '$lib/stores/accounts.svelte'
   import { getLayoutMode, hideViewer } from '$lib/stores/layout.svelte'
   import { isDialogGuardActive } from '$lib/stores/dialogGuard'
@@ -1603,7 +1603,7 @@
             {selectedMessageIds}
             selectedIsStarred={!selectedHasUnstarred}
             selectedIsRead={!selectedHasUnread}
-            showAccountIndicator={isUnifiedView}
+            showAccountIndicator={isUnifiedView && getShowAccountIndicators()}
             accountColor={resultAccountColor}
             accountName={resultAccountName}
             highlightedSubject={result.highlightedSubject}
@@ -1673,7 +1673,7 @@
           {selectedMessageIds}
           selectedIsStarred={!selectedHasUnstarred}
           selectedIsRead={!selectedHasUnread}
-          showAccountIndicator={isUnifiedView}
+          showAccountIndicator={isUnifiedView && getShowAccountIndicators()}
           accountColor={convAccountColor}
           accountName={convAccountName}
           onSelect={(e) => selectConversation(conv.threadId, index, e)}

--- a/frontend/src/lib/components/settings/GeneralTab.svelte
+++ b/frontend/src/lib/components/settings/GeneralTab.svelte
@@ -30,6 +30,7 @@
     showMessageListCircles: boolean
     showViewerCircles: boolean
     darkMailContent: boolean
+    showAccountIndicators: boolean
   }
 
   let {
@@ -54,6 +55,7 @@
     showMessageListCircles = $bindable(),
     showViewerCircles = $bindable(),
     darkMailContent = $bindable(),
+    showAccountIndicators = $bindable(),
   }: Props = $props()
 
   // Message list density options
@@ -284,6 +286,22 @@
         <Switch
           id="show-message-list-circles"
           bind:checked={showMessageListCircles}
+        />
+      </div>
+    </div>
+
+    <!-- Show account indicators in unified inbox -->
+    <div class="space-y-2">
+      <div class="flex items-center justify-between">
+        <div>
+          <Label for="show-account-indicators">Show account indicators</Label>
+          <p class="text-xs text-muted-foreground">
+            Show colored account tags on messages in unified inbox
+          </p>
+        </div>
+        <Switch
+          id="show-account-indicators"
+          bind:checked={showAccountIndicators}
         />
       </div>
     </div>

--- a/frontend/src/lib/components/settings/SettingsDialog.svelte
+++ b/frontend/src/lib/components/settings/SettingsDialog.svelte
@@ -5,9 +5,9 @@
   import * as Tabs from '$lib/components/ui/tabs'
   import { Button } from '$lib/components/ui/button'
   // @ts-ignore - wailsjs path
-  import { GetReadReceiptResponsePolicy, SetReadReceiptResponsePolicy, GetMarkAsReadDelay, SetMarkAsReadDelay, GetMessageListDensity, SetMessageListDensity, GetThemeMode, SetThemeMode, GetShowTitleBar, SetShowTitleBar, GetRunBackground, SetRunBackground, GetStartHidden, SetStartHidden, GetAutostart, SetAutostart, GetLanguage, SetLanguage, GetComposerMode, SetComposerMode, GetMailtoMode, SetMailtoMode, GetComposerFormat, SetComposerFormat, GetNativeTitleBar, SetNativeTitleBar, GetAlwaysLoadImages, SetAlwaysLoadImages, GetDarkMailContent, SetDarkMailContent, GetAccentBarUnread, SetAccentBarUnread, GetShowMessageListCircles, SetShowMessageListCircles, GetShowViewerCircles, SetShowViewerCircles, QuitApp } from '../../../../wailsjs/go/app/App.js'
+  import { GetReadReceiptResponsePolicy, SetReadReceiptResponsePolicy, GetMarkAsReadDelay, SetMarkAsReadDelay, GetMessageListDensity, SetMessageListDensity, GetThemeMode, SetThemeMode, GetShowTitleBar, SetShowTitleBar, GetRunBackground, SetRunBackground, GetStartHidden, SetStartHidden, GetAutostart, SetAutostart, GetLanguage, SetLanguage, GetComposerMode, SetComposerMode, GetMailtoMode, SetMailtoMode, GetComposerFormat, SetComposerFormat, GetNativeTitleBar, SetNativeTitleBar, GetAlwaysLoadImages, SetAlwaysLoadImages, GetDarkMailContent, SetDarkMailContent, GetAccentBarUnread, SetAccentBarUnread, GetShowMessageListCircles, SetShowMessageListCircles, GetShowViewerCircles, SetShowViewerCircles, GetShowAccountIndicators, SetShowAccountIndicators, QuitApp } from '../../../../wailsjs/go/app/App.js'
   import { addToast } from '$lib/stores/toast'
-  import { setMessageListDensity as updateDensityStore, setThemeMode as updateThemeStore, setShowTitleBar as updateShowTitleBarStore, setRunBackground as updateRunBackgroundStore, setStartHidden as updateStartHiddenStore, setAutostart as updateAutostartStore, setLanguage as updateLanguageStore, setComposerMode as updateComposerModeStore, setMailtoMode as updateMailtoModeStore, setComposerFormat as updateComposerFormatStore, setNativeTitleBar as updateNativeTitleBarStore, setAlwaysLoadImages as updateAlwaysLoadImagesStore, setDarkMailContent as updateDarkMailContentStore, setAccentBarUnread as updateAccentBarUnreadStore, setShowMessageListCircles as updateShowMessageListCirclesStore, setShowViewerCircles as updateShowViewerCirclesStore, type MessageListDensity, type ThemeMode, type ComposerMode, type ComposerFormat } from '$lib/stores/settings.svelte'
+  import { setMessageListDensity as updateDensityStore, setThemeMode as updateThemeStore, setShowTitleBar as updateShowTitleBarStore, setRunBackground as updateRunBackgroundStore, setStartHidden as updateStartHiddenStore, setAutostart as updateAutostartStore, setLanguage as updateLanguageStore, setComposerMode as updateComposerModeStore, setMailtoMode as updateMailtoModeStore, setComposerFormat as updateComposerFormatStore, setNativeTitleBar as updateNativeTitleBarStore, setAlwaysLoadImages as updateAlwaysLoadImagesStore, setDarkMailContent as updateDarkMailContentStore, setAccentBarUnread as updateAccentBarUnreadStore, setShowMessageListCircles as updateShowMessageListCirclesStore, setShowViewerCircles as updateShowViewerCirclesStore, setShowAccountIndicators as updateShowAccountIndicatorsStore, type MessageListDensity, type ThemeMode, type ComposerMode, type ComposerFormat } from '$lib/stores/settings.svelte'
   import { applyThemeFromMode } from '$lib/stores/theme.svelte'
   import { dialogGuardOpen, dialogGuardClose } from '$lib/stores/dialogGuard'
   import { _ } from '$lib/i18n'
@@ -50,6 +50,7 @@
   let accentBarUnread = $state<boolean>(false)
   let showMessageListCircles = $state<boolean>(true)
   let showViewerCircles = $state<boolean>(true)
+  let showAccountIndicators = $state<boolean>(true)
   let originalNativeTitleBar = false
   // Snapshot of the saved theme at dialog open time. Used to revert live preview
   // if the dialog closes without Save (Cancel / ESC / click-outside).
@@ -94,7 +95,7 @@
     loading = true
     hasSaved = false
     try {
-      const [policy, delayMs, density, theme, titleBar, runBg, startHid, autoSt, lang, comp, mail, compFmt, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles] = await Promise.all([
+      const [policy, delayMs, density, theme, titleBar, runBg, startHid, autoSt, lang, comp, mail, compFmt, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles, accountIndicators] = await Promise.all([
         GetReadReceiptResponsePolicy(),
         GetMarkAsReadDelay(),
         GetMessageListDensity(),
@@ -113,6 +114,7 @@
         GetAccentBarUnread(),
         GetShowMessageListCircles(),
         GetShowViewerCircles(),
+        GetShowAccountIndicators(),
       ])
       readReceiptResponsePolicy = policy
       // Convert ms to seconds for display
@@ -134,6 +136,7 @@
       accentBarUnread = accentBar ?? false
       showMessageListCircles = listCircles ?? true
       showViewerCircles = viewerCircles ?? true
+      showAccountIndicators = accountIndicators ?? true
       originalNativeTitleBar = nativeTitleBar
     } catch (err) {
       console.error('Failed to load settings:', err)
@@ -169,6 +172,7 @@
       await SetAccentBarUnread(accentBarUnread)
       await SetShowMessageListCircles(showMessageListCircles)
       await SetShowViewerCircles(showViewerCircles)
+      await SetShowAccountIndicators(showAccountIndicators)
       // Update the reactive stores so UI updates immediately
       updateDensityStore(messageListDensity as MessageListDensity)
       updateThemeStore(themeMode as ThemeMode)
@@ -188,6 +192,7 @@
       updateAccentBarUnreadStore(accentBarUnread)
       updateShowMessageListCirclesStore(showMessageListCircles)
       updateShowViewerCirclesStore(showViewerCircles)
+      updateShowAccountIndicatorsStore(showAccountIndicators)
       addToast({
         type: 'success',
         message: $_('toast.settingsSaved'),
@@ -299,6 +304,7 @@
               bind:accentBarUnread
               bind:showMessageListCircles
               bind:showViewerCircles
+              bind:showAccountIndicators
               bind:darkMailContent
             />
           </Tabs.Content>

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -2,7 +2,7 @@
 // Provides reactive state for application settings
 
 // @ts-ignore - wailsjs path
-import { GetMessageListDensity, GetMessageListSortOrder, GetThemeMode, GetShowTitleBar, GetRunBackground, GetStartHidden, GetAutostart, GetLanguage, GetComposerMode, GetMailtoMode, GetComposerFormat, GetNativeTitleBar, GetAlwaysLoadImages, GetDarkMailContent, GetAccentBarUnread, GetShowMessageListCircles, GetShowViewerCircles } from '../../../wailsjs/go/app/App'
+import { GetMessageListDensity, GetMessageListSortOrder, GetThemeMode, GetShowTitleBar, GetRunBackground, GetStartHidden, GetAutostart, GetLanguage, GetComposerMode, GetMailtoMode, GetComposerFormat, GetNativeTitleBar, GetAlwaysLoadImages, GetDarkMailContent, GetAccentBarUnread, GetShowMessageListCircles, GetShowViewerCircles, GetShowAccountIndicators } from '../../../wailsjs/go/app/App'
 import { setLocale as setI18nLocale } from '$lib/i18n'
 import { loadDateFnsLocale, getDateFnsLocale } from '$lib/i18n/dateFnsLocale'
 import type { Locale } from 'date-fns'
@@ -40,6 +40,7 @@ let darkMailContent = $state<boolean>(false)
 let accentBarUnread = $state<boolean>(false)
 let showMessageListCircles = $state<boolean>(true)
 let showViewerCircles = $state<boolean>(true)
+let showAccountIndicators = $state<boolean>(true)
 
 // Getter functions to access the state
 export function getMessageListDensity(): MessageListDensity {
@@ -108,6 +109,14 @@ export function getShowMessageListCircles(): boolean {
 
 export function getShowViewerCircles(): boolean {
   return showViewerCircles
+}
+
+export function getShowAccountIndicators(): boolean {
+  return showAccountIndicators
+}
+
+export function setShowAccountIndicators(v: boolean) {
+  showAccountIndicators = v
 }
 
 export function getCurrentDateFnsLocale(): Locale | undefined {
@@ -190,7 +199,7 @@ export function setShowViewerCircles(v: boolean) {
 // Load settings from backend (call on app startup)
 export async function loadSettings(): Promise<ThemeMode> {
   try {
-    const [density, sortOrder, theme, titleBar, runBg, startHid, autoSt, lang, compMode, mailMode, compFormat, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles] = await Promise.all([
+    const [density, sortOrder, theme, titleBar, runBg, startHid, autoSt, lang, compMode, mailMode, compFormat, nativeTB, alwaysImages, darkMail, accentBar, listCircles, viewerCircles, accountIndicators] = await Promise.all([
       GetMessageListDensity(),
       GetMessageListSortOrder(),
       GetThemeMode(),
@@ -208,6 +217,7 @@ export async function loadSettings(): Promise<ThemeMode> {
       GetAccentBarUnread(),
       GetShowMessageListCircles(),
       GetShowViewerCircles(),
+      GetShowAccountIndicators(),
     ])
     messageListDensity = (density as MessageListDensity) || 'standard'
     messageListSortOrder = (sortOrder as MessageListSortOrder) || 'newest'
@@ -225,6 +235,7 @@ export async function loadSettings(): Promise<ThemeMode> {
     accentBarUnread = accentBar ?? false
     showMessageListCircles = listCircles ?? true
     showViewerCircles = viewerCircles ?? true
+    showAccountIndicators = accountIndicators ?? true
     // Apply saved language (if set, overrides system detection from initI18n)
     if (lang) {
       language = lang

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -101,6 +101,10 @@ export function ForceSyncFolder(arg1:string,arg2:string):Promise<void>;
 
 export function GetAccentBarUnread():Promise<boolean>;
 
+export function GetShowAccountIndicators():Promise<boolean>;
+
+export function SetShowAccountIndicators(arg1:boolean):Promise<void>;
+
 export function GetAccount(arg1:string):Promise<account.Account>;
 
 export function GetAccountFoldersForMapping(arg1:string):Promise<Array<folder.Folder>>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -170,6 +170,14 @@ export function GetAccentBarUnread() {
   return window['go']['app']['App']['GetAccentBarUnread']();
 }
 
+export function GetShowAccountIndicators() {
+  return window['go']['app']['App']['GetShowAccountIndicators']();
+}
+
+export function SetShowAccountIndicators(arg1) {
+  return window['go']['app']['App']['SetShowAccountIndicators'](arg1);
+}
+
 export function GetAccount(arg1) {
   return window['go']['app']['App']['GetAccount'](arg1);
 }

--- a/internal/settings/store.go
+++ b/internal/settings/store.go
@@ -34,6 +34,7 @@ const (
 	KeyAccentBarUnread           = "accent_bar_unread"
 	KeyShowMessageListCircles    = "show_message_list_circles"
 	KeyShowViewerCircles         = "show_viewer_circles"
+	KeyShowAccountIndicators     = "show_account_indicators"
 )
 
 // Density values for message list
@@ -580,4 +581,25 @@ func ReadNativeTitleBar(dbPath string) bool {
 		return false
 	}
 	return value == "true"
+}
+
+// GetShowAccountIndicators returns whether account indicator tags are shown in unified inbox.
+func (s *Store) GetShowAccountIndicators() (bool, error) {
+	value, err := s.Get(KeyShowAccountIndicators)
+	if err != nil {
+		return true, err
+	}
+	if value == "" {
+		return true, nil
+	}
+	return value == "true", nil
+}
+
+// SetShowAccountIndicators enables or disables account indicator tags in unified inbox.
+func (s *Store) SetShowAccountIndicators(enabled bool) error {
+	v := "false"
+	if enabled {
+		v = "true"
+	}
+	return s.Set(KeyShowAccountIndicators, v)
 }


### PR DESCRIPTION
## What

Adds a **"Show account indicators"** toggle to Settings → General (closes #244). When disabled, the per-account colored tags on messages in the **unified inbox** are hidden. Defaults to **on** (current behavior preserved).

- Setting persisted (`show_account_indicators`, default `true`) — `GetShowAccountIndicators`/`SetShowAccountIndicators` backend + wails bindings
- `MessageList` gates the existing `showAccountIndicator` on the setting (`isUnifiedView && getShowAccountIndicators()`)
- Toggle switch wired into the General tab

## Closes

Closes #244

## Notes (transparency)

- **AI-assisted**. Un-bundled from a larger local branch (v0.2.5 base); targeted at `main` (applies cleanly). Happy to retarget to `v0.3.0-dev`.
- This PR gates the **existing** indicator; it does not include the separate indicator visual redesign from my local branch.
- Verified locally: `go build ./...` OK, `eslint` clean, `svelte-check` 0/0, `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
