### PR TITLE
fix: unified inbox freeze on duplicate conversation render key

### DIFF
--- a/frontend/src/lib/components/list/MessageList.svelte
+++ b/frontend/src/lib/components/list/MessageList.svelte
@@ -1657,7 +1657,7 @@
         </button>
       </div>
     {:else}
-      {#each conversations as conv, index (conv.threadId)}
+      {#each conversations as conv, index (conv.threadId + '-' + ((conv as any).accountId || accountId || ''))}
         {@const convAccountId = (conv as any).accountId || accountId}
         {@const convFolderId = (conv as any).folderId || folderId}
         {@const convAccountColor = (conv as any).accountColor || ''}


### PR DESCRIPTION
## What

Fixes the unified-inbox freeze from #241.

In the unified inbox the same `threadId` can appear for **multiple accounts**, so the conversation `{#each ... (conv.threadId)}` produced **duplicate keys**. Svelte's keyed-each can't handle duplicate keys and the list stops rendering (freeze).

Fix: make the key unique by combining `threadId` with the conversation's account id:

```svelte
{#each conversations as conv, index (conv.threadId + '-' + ((conv as any).accountId || accountId || ''))}
```

## Closes

Closes #241

## Notes (transparency)

- **AI-assisted**. Un-bundled from a larger local branch (v0.2.5 base); targeted at `main` (applies cleanly). Happy to retarget to `v0.3.0-dev`.
- Verified locally: `svelte-check` 0/0, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
