### PR TITLE
fix: auto mark-as-read no longer pollutes the undo stack

### DIFF
--- a/app/actions.go
+++ b/app/actions.go
@@ -55,7 +55,14 @@ func (a *App) withIMAPRetry(accountID string, op func(conn *imap.Client) error) 
 
 // MarkAsRead marks messages as read
 func (a *App) MarkAsRead(messageIDs []string) error {
-	return a.setReadStatus(messageIDs, true)
+	return a.setReadStatus(messageIDs, true, true)
+}
+
+// MarkAsReadSilent marks messages as read WITHOUT pushing an undo command.
+// Used for automatic mark-as-read when opening a message, so Cmd+Z doesn't
+// get flooded with "Mark as read" entries that bury the user's real action.
+func (a *App) MarkAsReadSilent(messageIDs []string) error {
+	return a.setReadStatus(messageIDs, true, false)
 }
 
 // MarkAllFolderMessagesAsRead marks all unread messages in a folder as read
@@ -84,10 +91,10 @@ func (a *App) MarkAllFolderMessagesAsUnread(folderID string) error {
 
 // MarkAsUnread marks messages as unread
 func (a *App) MarkAsUnread(messageIDs []string) error {
-	return a.setReadStatus(messageIDs, false)
+	return a.setReadStatus(messageIDs, false, true)
 }
 
-func (a *App) setReadStatus(messageIDs []string, isRead bool) error {
+func (a *App) setReadStatus(messageIDs []string, isRead bool, recordUndo bool) error {
 	log := logging.WithComponent("app")
 
 	if len(messageIDs) == 0 {
@@ -166,10 +173,10 @@ func (a *App) setReadStatus(messageIDs []string, isRead bool) error {
 		}
 	}()
 
-	// Create undo command
+	// Create undo command (skipped for automatic mark-as-read)
 	firstMsg := messages[0]
 	folderObj, _ := a.folderStore.Get(firstMsg.FolderID)
-	if folderObj != nil {
+	if recordUndo && folderObj != nil {
 		uids := make([]uint32, len(messages))
 		for i, m := range messages {
 			uids[i] = m.UID

--- a/frontend/src/lib/components/viewer/ConversationViewer.svelte
+++ b/frontend/src/lib/components/viewer/ConversationViewer.svelte
@@ -4,7 +4,7 @@
   // @ts-ignore - wailsjs bindings
   import { GetConversation, GetReadReceiptResponsePolicy, SendReadReceipt, IgnoreReadReceipt, GetMarkAsReadDelay, GetMessageSource, ProcessSMIMEMessage, ProcessPGPMessage, FetchMessageBody } from '../../../../wailsjs/go/app/App'
   // @ts-ignore - wailsjs bindings
-  import { MarkAsRead, MarkAsUnread, Star, Unstar, Archive, Trash, MarkAsSpam, MarkAsNotSpam, DeletePermanently, Undo } from '../../../../wailsjs/go/app/App'
+  import { MarkAsRead, MarkAsReadSilent, MarkAsUnread, Star, Unstar, Archive, Trash, MarkAsSpam, MarkAsNotSpam, DeletePermanently, Undo } from '../../../../wailsjs/go/app/App'
   // @ts-ignore - wailsjs path
   import { EventsOn } from '../../../../wailsjs/runtime/runtime'
   // @ts-ignore - wailsjs path
@@ -625,7 +625,7 @@
 
     if (markAsReadDelay === 0) {
       // Immediate
-      MarkAsRead(unreadIds).catch(err => {
+      MarkAsReadSilent(unreadIds).catch(err => {
         console.error('Failed to mark messages as read:', err)
         pendingMarkAsReadIds = new Set() // Clear on error
       })
@@ -634,7 +634,7 @@
       markAsReadTimer = setTimeout(() => {
         // Verify we're still viewing the same conversation
         if (threadId === capturedThreadId) {
-          MarkAsRead(unreadIds).catch(err => {
+          MarkAsReadSilent(unreadIds).catch(err => {
             console.error('Failed to mark messages as read:', err)
             pendingMarkAsReadIds = new Set() // Clear on error
           })

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -313,6 +313,8 @@ export function MarkAsNotSpam(arg1:Array<string>):Promise<void>;
 
 export function MarkAsRead(arg1:Array<string>):Promise<void>;
 
+export function MarkAsReadSilent(arg1:Array<string>):Promise<void>;
+
 export function MarkAsSpam(arg1:Array<string>):Promise<boolean>;
 
 export function MarkAsUnread(arg1:Array<string>):Promise<void>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -594,6 +594,10 @@ export function MarkAsRead(arg1) {
   return window['go']['app']['App']['MarkAsRead'](arg1);
 }
 
+export function MarkAsReadSilent(arg1) {
+  return window['go']['app']['App']['MarkAsReadSilent'](arg1);
+}
+
 export function MarkAsSpam(arg1) {
   return window['go']['app']['App']['MarkAsSpam'](arg1);
 }


### PR DESCRIPTION
## What

Fixes auto mark-as-read polluting the undo stack (#243).

Opening a message auto-marks it read after the configured delay — and each auto-mark pushed an undo command. So **Cmd+Z undid "Mark as read"** instead of the user's last real action (archive / move / delete…), which the issue reports as the wrong thing being undone.

Fix:
- New `MarkAsReadSilent` (= `setReadStatus(ids, true, recordUndo=false)`) that does **not** push an undo command
- `ConversationViewer` uses it for the **automatic** open-message mark-as-read (both immediate and delayed paths)
- **Manual** mark read/unread (toolbar/keyboard) still records undo, unchanged

## Closes

Closes #243

## Notes (transparency)

- **AI-assisted**. Un-bundled from a larger local branch (v0.2.5 base); targeted at `main` (applies cleanly). Happy to retarget to `v0.3.0-dev`.
- Verified locally: `go build ./...` OK, `eslint` clean, `svelte-check` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
