### PR TITLE
feat: enable spell checking in composer (Linux/WebKitGTK)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 5m
+  build-tags:
+    - webkit2_41
 
 linters:
   disable:

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ generate:
 # Run Go tests
 test:
 	@echo "Running tests..."
-	go test ./...
+	go test -tags $(BUILD_TAGS) ./...
 
 # Run all linters (Go + frontend)
 lint: lint-go lint-frontend

--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,8 @@ import (
 	goSync "sync"
 	"time"
 
+	extcalendarbe "github.com/hkdb/aerion/extensions/calendar/backend"
+	extcontactsbe "github.com/hkdb/aerion/extensions/contacts/backend"
 	"github.com/hkdb/aerion/internal/account"
 	"github.com/hkdb/aerion/internal/appstate"
 	"github.com/hkdb/aerion/internal/carddav"
@@ -20,8 +22,6 @@ import (
 	"github.com/hkdb/aerion/internal/credentials"
 	"github.com/hkdb/aerion/internal/database"
 	"github.com/hkdb/aerion/internal/draft"
-	extcalendarbe "github.com/hkdb/aerion/extensions/calendar/backend"
-	extcontactsbe "github.com/hkdb/aerion/extensions/contacts/backend"
 	extauth "github.com/hkdb/aerion/internal/extensions/auth"
 	extcompose "github.com/hkdb/aerion/internal/extensions/compose"
 	extmail "github.com/hkdb/aerion/internal/extensions/mail"
@@ -33,9 +33,9 @@ import (
 	"github.com/hkdb/aerion/internal/message"
 	"github.com/hkdb/aerion/internal/notification"
 	"github.com/hkdb/aerion/internal/oauth2"
+	"github.com/hkdb/aerion/internal/pgp"
 	"github.com/hkdb/aerion/internal/platform"
 	"github.com/hkdb/aerion/internal/settings"
-	"github.com/hkdb/aerion/internal/pgp"
 	"github.com/hkdb/aerion/internal/smime"
 	"github.com/hkdb/aerion/internal/sync"
 	"github.com/hkdb/aerion/internal/undo"
@@ -236,14 +236,14 @@ type App struct {
 	// into App via its Bridge struct (declared at the top of this struct
 	// definition); the *Extension field below is the lightweight lifecycle
 	// handle the host's knownExtensions Register loop iterates.
-	authBroker       *extauth.Broker      // coreapi.Auth impl for extensions
-	mailAPI          *extmail.API         // coreapi.Mail impl wrapping core stores
-	composerAPI      *extcompose.API      // coreapi.Composer impl wrapping OpenComposerWindow
-	uiRegistry       *extui.Registry      // coreapi.UI impl: rail tabs, account-setup hooks, ...
-	contactsExt      *extcontactsbe.Extension // Contacts lifecycle handle (manifest + Register only)
-	calendarExt      *extcalendarbe.Extension // Calendar lifecycle handle (manifest + Register only)
-	knownExtensions  []coreapi.Extension      // all first-party extensions, iterated by ListExtensions
-	extensionUnregs  []coreapi.Unregister     // teardown funcs returned from each Extension.Register
+	authBroker      *extauth.Broker          // coreapi.Auth impl for extensions
+	mailAPI         *extmail.API             // coreapi.Mail impl wrapping core stores
+	composerAPI     *extcompose.API          // coreapi.Composer impl wrapping OpenComposerWindow
+	uiRegistry      *extui.Registry          // coreapi.UI impl: rail tabs, account-setup hooks, ...
+	contactsExt     *extcontactsbe.Extension // Contacts lifecycle handle (manifest + Register only)
+	calendarExt     *extcalendarbe.Extension // Calendar lifecycle handle (manifest + Register only)
+	knownExtensions []coreapi.Extension      // all first-party extensions, iterated by ListExtensions
+	extensionUnregs []coreapi.Unregister     // teardown funcs returned from each Extension.Register
 
 	// coreapi.EventBus implementation, lazily constructed on first
 	// Core.Events() call (via eventBusInitOnce). Extensions consume via
@@ -310,7 +310,7 @@ type App struct {
 
 	// Draft IMAP sync goroutine tracking — cancel in-flight syncDraftToIMAP
 	draftSyncContexts map[string]context.CancelFunc // keyed by draft ID
-	draftSyncDone     map[string]chan struct{}       // closed when goroutine exits
+	draftSyncDone     map[string]chan struct{}      // closed when goroutine exits
 
 	// Sleep/wake detection for auto-sync on wake
 	sleepWakeMonitor platform.SleepWakeMonitor
@@ -792,6 +792,9 @@ func (a *App) Startup(ctx context.Context) {
 
 	// Initialize autostart manager
 	a.autostartMgr = platform.NewAutostartManager()
+
+	// Enable spell checking in the WebView (Linux/WebKitGTK)
+	platform.EnableSpellChecking()
 
 	log.Info().Msg("Aerion started successfully")
 }

--- a/frontend/src/lib/components/composer/composerEditor.ts
+++ b/frontend/src/lib/components/composer/composerEditor.ts
@@ -233,6 +233,7 @@ export function createComposerEditor(
     editorProps: {
       attributes: {
         class: 'composer-editor focus:outline-none min-h-[200px] p-3',
+        spellcheck: 'true',
       },
       // Handle paste events for images
       handlePaste: (view, event) => {

--- a/internal/platform/spellcheck_linux.go
+++ b/internal/platform/spellcheck_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package platform
+
+/*
+#cgo !webkit2_41 pkg-config: webkit2gtk-4.0 glib-2.0
+#cgo webkit2_41 pkg-config: webkit2gtk-4.1 glib-2.0
+#include <webkit2/webkit2.h>
+#include <glib.h>
+
+static gboolean enable_spellcheck_cb(gpointer data) {
+WebKitWebContext *ctx = webkit_web_context_get_default();
+webkit_web_context_set_spell_checking_enabled(ctx, TRUE);
+
+const char *lang = g_getenv("LANG");
+if (lang == NULL || lang[0] == 0) {
+lang = "en_US";
+}
+gchar **parts = g_strsplit(lang, ".", 2);
+const gchar *langs[] = { parts[0], NULL };
+webkit_web_context_set_spell_checking_languages(ctx, langs);
+g_strfreev(parts);
+
+return G_SOURCE_REMOVE;
+}
+
+static void schedule_enable_spellcheck() {
+g_idle_add(enable_spellcheck_cb, NULL);
+}
+*/
+import "C"
+
+// EnableSpellChecking enables spell checking on the default WebKit web context
+// using the system enchant/hunspell dictionaries. Language is derived from
+// the LANG environment variable. Dispatched to the GTK main thread.
+func EnableSpellChecking() {
+	C.schedule_enable_spellcheck()
+}

--- a/internal/platform/spellcheck_other.go
+++ b/internal/platform/spellcheck_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package platform
+
+// EnableSpellChecking is a no-op on non-Linux platforms, where the native
+// WebView handles spell checking automatically.
+func EnableSpellChecking() {}


### PR DESCRIPTION
Follow-up to #89, which intentionally left out spellchecking ("this PR does not add custom Aerion-specific context-menu actions or spellchecking"). This PR adds it for the Linux build.
Approach

Set spellcheck: 'true' on the TipTap editor attributes in composerEditor.ts
The HTML attribute alone isn't enough on WebKitGTK — the web context needs webkit_web_context_set_spell_checking_enabled(). Added a small CGo helper in internal/platform/spellcheck_linux.go following the existing startup_linux.go pattern, with a no-op stub for other platforms (spellcheck_other.go).
Language is derived from the LANG env variable; uses the system's enchant/hunspell dictionaries.

Validation

npm run check ✅ / npm run build ✅
gofmt clean, no new go vet warnings
Tested on CachyOS (WebKitGTK 4.1): red squiggles + native right-click suggestions work

Open questions

Should this be a Settings toggle rather than always-on?
macOS/Windows WebViews handle spellcheck natively — happy to confirm/adjust if needed.

Related to #89.