### PR TITLE
feat: add Empty Junk action to junk/spam folder

### DIFF
--- a/app/actions.go
+++ b/app/actions.go
@@ -1067,6 +1067,18 @@ func (a *App) EmptyTrash(accountID, folderID string) error {
 	return a.DeletePermanently(ids)
 }
 
+// EmptyJunk permanently deletes all messages in a junk/spam folder
+func (a *App) EmptyJunk(accountID, folderID string) error {
+	ids, err := a.messageStore.GetAllIDsByFolder(folderID)
+	if err != nil {
+		return fmt.Errorf("failed to get messages in junk: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return a.DeletePermanently(ids)
+}
+
 // DeletePermanently permanently deletes messages
 func (a *App) DeletePermanently(messageIDs []string) error {
 	log := logging.WithComponent("app")

--- a/frontend/src/lib/components/list/MessageList.svelte
+++ b/frontend/src/lib/components/list/MessageList.svelte
@@ -6,7 +6,7 @@
   import { cn } from '$lib/utils'
   import { Button } from '$lib/components/ui/button'
   // @ts-ignore - wailsjs bindings
-  import { GetConversations, GetConversationCount, SyncFolder, ForceSyncFolder, CancelFolderSync, SetMessageListSortOrder, GetUnifiedInboxConversations, GetUnifiedInboxCount, SearchConversations, SearchUnifiedInbox, GetSearchCount, GetSearchCountUnifiedInbox, GetFTSIndexStatus, IsFTSIndexing, Trash, DeletePermanently, EmptyTrash, Undo, IMAPSearchFolder, FetchServerMessage } from '../../../../wailsjs/go/app/App'
+  import { GetConversations, GetConversationCount, SyncFolder, ForceSyncFolder, CancelFolderSync, SetMessageListSortOrder, GetUnifiedInboxConversations, GetUnifiedInboxCount, SearchConversations, SearchUnifiedInbox, GetSearchCount, GetSearchCountUnifiedInbox, GetFTSIndexStatus, IsFTSIndexing, Trash, DeletePermanently, EmptyTrash, EmptyJunk, Undo, IMAPSearchFolder, FetchServerMessage } from '../../../../wailsjs/go/app/App'
   import { toasts } from '$lib/stores/toast'
   import { _ } from '$lib/i18n'
   import { ConfirmDialog } from '$lib/components/ui/confirm-dialog'
@@ -1178,6 +1178,9 @@
   // Empty trash confirmation state
   let showEmptyTrashConfirm = $state(false)
 
+  // Empty junk confirmation state
+  let showEmptyJunkConfirm = $state(false)
+
   async function handleUndo() {
     try {
       const description = await Undo()
@@ -1214,6 +1217,20 @@
       toasts.error($_('toast.failedToEmptyTrash'))
     }
     showEmptyTrashConfirm = false
+  }
+
+  async function handleEmptyJunk() {
+    if (!accountId || !folderId) return
+    try {
+      await EmptyJunk(accountId, folderId)
+      toasts.success($_('toast.junkEmptied'))
+      handleActionComplete(true)
+      clearChecked()
+    } catch (err) {
+      console.error('Empty junk failed:', err)
+      toasts.error($_('toast.failedToEmptyJunk'))
+    }
+    showEmptyJunkConfirm = false
   }
 
   // Shared delete handler — same flow as context menu "Delete" action
@@ -1447,6 +1464,21 @@
       >
         <Icon icon="mdi:delete-sweep-outline" class="w-4 h-4 mr-1.5" />
         {$_('messageList.emptyTrash')}
+      </Button>
+    </div>
+  {/if}
+
+  <!-- Empty Junk bar (only shown when viewing junk/spam folder with messages, not in search mode) -->
+  {#if folderType === 'spam' && totalCount > 0 && !isSearchMode}
+    <div class="flex items-center justify-end px-4 py-2 bg-muted/50 border-b border-border">
+      <Button
+        size="sm"
+        variant="outline"
+        class="text-destructive hover:text-destructive hover:bg-destructive/10 border-destructive/50 bg-muted/50"
+        onclick={() => { showEmptyJunkConfirm = true }}
+      >
+        <Icon icon="mdi:delete-sweep-outline" class="w-4 h-4 mr-1.5" />
+        {$_('messageList.emptyJunk')}
       </Button>
     </div>
   {/if}
@@ -1725,4 +1757,15 @@
   variant="destructive"
   onConfirm={handleEmptyTrash}
   onCancel={() => { showEmptyTrashConfirm = false }}
+/>
+
+<!-- Empty Junk Confirmation Dialog -->
+<ConfirmDialog
+  bind:open={showEmptyJunkConfirm}
+  title={$_('dialog.emptyJunk')}
+  description={$_('dialog.emptyJunkDescription')}
+  confirmLabel={$_('dialog.confirmEmptyJunk')}
+  variant="destructive"
+  onConfirm={handleEmptyJunk}
+  onCancel={() => { showEmptyJunkConfirm = false }}
 />

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -52,6 +52,7 @@
     "noMessages": "No messages in this folder",
     "selectFolder": "Select a folder to view messages",
     "emptyTrash": "Empty Trash",
+    "emptyJunk": "Empty Junk",
     "ftsBuilding": "Building search index... ({percentage}%)",
     "syncFolder": "Sync Folder",
     "forceResync": "Force Re-sync",
@@ -260,6 +261,7 @@
     "deletedFromFolder": "Deleted from folder",
     "permanentlyDeleted": "Permanently deleted",
     "trashEmptied": "Trash emptied",
+    "junkEmptied": "Junk emptied",
     "markedAsRead": "Marked as read",
     "markedAsUnread": "Marked as unread",
     "markedAsSpam": "Marked as spam",
@@ -282,6 +284,7 @@
     "failedToArchive": "Failed to archive.",
     "failedToDelete": "Failed to delete.",
     "failedToEmptyTrash": "Failed to empty trash.",
+    "failedToEmptyJunk": "Failed to empty junk.",
     "failedToMarkAsRead": "Failed to mark as read.",
     "failedToMarkAsUnread": "Failed to mark as unread.",
     "failedToMarkAsSpam": "Failed to mark as spam.",
@@ -814,7 +817,10 @@
     "emptyTrash": "Empty Trash?",
     "emptyTrashDescription": "This will permanently delete all messages in the Trash folder. This action cannot be undone.",
     "confirmDeletePermanently": "Delete Permanently",
-    "confirmEmptyTrash": "Empty Trash"
+    "confirmEmptyTrash": "Empty Trash",
+    "emptyJunk": "Empty Junk?",
+    "emptyJunkDescription": "This will permanently delete all messages in the Junk folder. This action cannot be undone.",
+    "confirmEmptyJunk": "Empty Junk"
   },
   "date": {
     "justNow": "just now",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -52,6 +52,7 @@
     "noMessages": "Aucun message dans ce dossier",
     "selectFolder": "Sélectionnez un dossier pour voir les messages",
     "emptyTrash": "Vider la corbeille",
+    "emptyJunk": "Vider les indésirables",
     "ftsBuilding": "Construction de l'index de recherche... ({percentage}%)",
     "syncFolder": "Synchroniser le dossier",
     "forceResync": "Forcer la synchronisation",
@@ -260,6 +261,7 @@
     "deletedFromFolder": "Supprimé du dossier",
     "permanentlyDeleted": "Supprimé définitivement",
     "trashEmptied": "Corbeille vidée",
+    "junkEmptied": "Courriers indésirables vidés",
     "markedAsRead": "Marqué comme lu",
     "markedAsUnread": "Marqué comme non lu",
     "markedAsSpam": "Marqué comme spam",
@@ -280,6 +282,7 @@
     "failedToArchive": "Échec de l'archivage.",
     "failedToDelete": "Échec de la suppression.",
     "failedToEmptyTrash": "Échec de la vidange de la corbeille.",
+    "failedToEmptyJunk": "Échec de la vidange des indésirables.",
     "failedToMarkAsRead": "Échec du marquage comme lu.",
     "failedToMarkAsUnread": "Échec du marquage comme non lu.",
     "failedToMarkAsSpam": "Échec du marquage comme spam.",
@@ -778,7 +781,10 @@
     "emptyTrash": "Vider la corbeille ?",
     "emptyTrashDescription": "Ceci supprimera définitivement tous les messages de la Corbeille. Cette action est irréversible.",
     "confirmDeletePermanently": "Supprimer définitivement",
-    "confirmEmptyTrash": "Vider la corbeille"
+    "confirmEmptyTrash": "Vider la corbeille",
+    "emptyJunk": "Vider les indésirables ?",
+    "emptyJunkDescription": "Ceci supprimera définitivement tous les messages du dossier Indésirables. Cette action est irréversible.",
+    "confirmEmptyJunk": "Vider les indésirables"
   },
   "date": {
     "justNow": "à l'instant",

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -177,6 +177,8 @@ export function DownloadAttachment(arg1:string,arg2:string):Promise<string>;
 
 export function DownloadEncryptedAttachment(arg1:string,arg2:string,arg3:string):Promise<string>;
 
+export function EmptyJunk(arg1:string,arg2:string):Promise<void>;
+
 export function EmptyTrash(arg1:string,arg2:string):Promise<void>;
 
 export function FetchMessageBody(arg1:string):Promise<message.Message>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -318,6 +318,10 @@ export function DownloadEncryptedAttachment(arg1, arg2, arg3) {
   return window['go']['app']['App']['DownloadEncryptedAttachment'](arg1, arg2, arg3);
 }
 
+export function EmptyJunk(arg1, arg2) {
+  return window['go']['app']['App']['EmptyJunk'](arg1, arg2);
+}
+
 export function EmptyTrash(arg1, arg2) {
   return window['go']['app']['App']['EmptyTrash'](arg1, arg2);
 }


### PR DESCRIPTION
Adds an "Empty Junk" action to the Junk/Spam folder, mirroring the existing "Empty Trash" functionality.
Changes

Backend: new EmptyJunk(accountID, folderID) method in app/actions.go, mirroring EmptyTrash (uses GetAllIDsByFolder + DeletePermanently)
Frontend (MessageList.svelte): action bar + confirmation dialog, shown only when viewing a folder with type spam and not in search mode
i18n: added keys in both en.json and fr.json (messageList.emptyJunk, toast.junkEmptied, toast.failedToEmptyJunk, dialog.emptyJunk, dialog.emptyJunkDescription, dialog.confirmEmptyJunk)

Validation

make test ✅ / npm run check ✅ / npm run build ✅
Condition folderType === 'spam' matches the backend TypeSpam = "spam" definition, symmetric with the existing trash button