### PR TITLE
i18n: add French translation for spellcheck settings

### DIFF
--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -1,4 +1,17 @@
 {
+  "spellcheck": {
+    "title": "Vérification orthographique",
+    "enable": "Vérifier l'orthographe",
+    "enableHelp": "Souligner les mots mal orthographiés lors de la rédaction.",
+    "languages": "Dictionnaires",
+    "languagesHelp": "Un mot est accepté s'il est valide dans l'une des langues activées.",
+    "addToDictionary": "Ajouter au dictionnaire",
+    "ignore": "Ignorer",
+    "noSuggestions": "Aucune suggestion",
+    "addedWords": "Mots ajoutés",
+    "noAddedWords": "Aucun mot ajouté pour l'instant.",
+    "removeWord": "Supprimer le mot"
+  },
   "common": {
     "save": "Enregistrer",
     "cancel": "Annuler",


### PR DESCRIPTION
Adds the French translation for the new spellcheck.* settings keys requested in #297.
Changes

spellcheck.* (11 keys) — spellcheck/dictionary UI strings, using standard French terminology (e.g. "Vérification orthographique", "Ajouter au dictionnaire", "Souligner les mots mal orthographiés lors de la rédaction")

Note: toast.accountEmailExists was already translated on v0.3.2-dev, so it's not included here.
Validation

npm run check ✅ (0 errors)
npm run build ✅
Full key parity with en.json verified (0 missing keys)
Trailing newline preserved

Related to #297.