### PR TITLE
docs(README): add repology vertical badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ A standalone lightweight e-mail client inspired by [Geary](https://wiki.gnome.or
 ### 🖥 OS Support
 ---
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/aerion.svg)](https://repology.org/project/aerion/versions)
+
+Pre-built binaries are also available in the [Release Assets](https://github.com/hkdb/aerion/releases).
+
 Although Linux is a first-class citizen here, it also works on:
 
 - MacOS


### PR DESCRIPTION
Hi @hkdb,
Good news – Aerion has been officially packaged in nixpkgs – our first distribution package! ([PR #521267](https://github.com/NixOS/nixpkgs/pull/521267#event-28258433427)). It will take a few days to roll into nixos-unstable, but I think it's time to add a Repology vertical badge to the README. This would help users easily check Aerion's availability in their distribution. Plus, it might encourage more distribution maintainers to package Aerion, making the software more broadly accessible and easier to install.