### PR TITLE
fix: Stop Escape closing the composer under a modal

### DIFF
--- a/frontend/src/lib/components/composer/Composer.svelte
+++ b/frontend/src/lib/components/composer/Composer.svelte
@@ -55,6 +55,7 @@
   import { addToast } from '$lib/stores/toast'
   import { getComposerFormat, getDarkComposerBody } from '$lib/stores/settings.svelte'
   import { getIsDarkActive } from '$lib/stores/theme.svelte'
+  import { isDialogGuardActive } from '$lib/stores/dialogGuard'
   import { _ } from '$lib/i18n'
 
   // Keep the composer message body white in dark mode unless the user opted into
@@ -1448,6 +1449,23 @@
       }
     }
     if (e.key === 'Escape') {
+      // Anything modal stacked on top owns Escape — don't also close the
+      // composer underneath it (which would pop the save-draft prompt, or
+      // re-open the one the user just dismissed).
+      //
+      // bits-ui's escape layer listens on `document` and calls
+      // preventDefault() without stopping propagation, so the event still
+      // reaches this window-level handler afterwards. defaultPrevented is the
+      // reliable signal: it persists across listeners in the same dispatch.
+      // A DOM check for [role=dialog] does NOT work here — a microtask
+      // checkpoint runs between listener callbacks, so Svelte has already
+      // flushed the dialog out of the DOM by the time this runs.
+      //
+      // This also covers layers that deliberately ignore Escape: bits-ui
+      // preventDefaults those too, and the composer shouldn't close under a
+      // modal that is refusing to.
+      if (e.defaultPrevented) return
+      if (isDialogGuardActive()) return
       handleClose()
     }
   }


### PR DESCRIPTION
Fixes the `Escape` handling conflict reported in #400.

### The bug

`Composer.svelte` binds a `svelte:window` keydown handler that calls `handleClose()` on bare `Escape` with no check for what is on screen. When a modal layer sits on top of the composer, both react to the same keypress:

- **Escape on the save-draft prompt did nothing.** bits-ui closed the dialog, then this handler immediately re-opened it.
- **A guarded modal over the composer** (Settings, folder picker) **was dismissed together with the composer underneath it**, popping the save-draft prompt.

### The fix

Bail out when a modal layer has already consumed the key:

```js
if (e.defaultPrevented) return
if (isDialogGuardActive()) return
handleClose()
```

### Why `defaultPrevented`

bits-ui's escape layer listens on `document` and calls `preventDefault()` **without** stopping propagation, so the event still reaches this window-level handler. `defaultPrevented` is the reliable signal because it persists across listeners within the same dispatch.

This covers every bits-ui layer — dialog, alertdialog, dropdown, context menu — whether or not it registers the dialog guard. That includes layers which deliberately ignore `Escape`: bits-ui `preventDefault`s those too, and the composer shouldn't close under a modal that is refusing to close itself.

A DOM check for `[role=dialog]` does **not** work here, which was the first approach tried. A microtask checkpoint runs between listener callbacks, so Svelte has already flushed the dialog out of the DOM by the time this handler runs and the query finds nothing.

### Testing

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- Both symptoms from #400 verified fixed by hand; `Escape` with no modal open still closes the composer as before.

### Notes

Targeting `v0.3.4-dev` per the release-branch convention. 18 added lines in one file, no behavior change when no modal is present.

I appreciate that CONTRIBUTING.md says the workflow isn't set up for general PRs yet — happy to leave this sitting until it is, or to close it and just keep #400 open as a report if that's easier for you.
